### PR TITLE
maxMsgSize should default to 1024 bytes

### DIFF
--- a/fido2/ctap2.py
+++ b/fido2/ctap2.py
@@ -81,7 +81,7 @@ class Info(bytes):
         self.extensions = data.get(Info.KEY.EXTENSIONS, [])
         self.aaguid = data[Info.KEY.AAGUID]
         self.options = data.get(Info.KEY.OPTIONS, {})
-        self.max_msg_size = data.get(Info.KEY.MAX_MSG_SIZE)
+        self.max_msg_size = data.get(Info.KEY.MAX_MSG_SIZE, 1024)
         self.pin_protocols = data.get(Info.KEY.PIN_PROTOCOLS, [])
         self.data = data
 


### PR DESCRIPTION
https://fidoalliance.org/specs/fido-v2.0-ps-20170927/fido-client-to-authenticator-protocol-v2.0-ps-20170927.html#message-encoding

> Likewise, because some authenticators are memory constrained, the maximum message size supported by an authenticator may be limited. By default, authenticators must support messages of at least 1024 bytes. Authenticators may declare a different maximum message size supported using the maxMsgSize authenticatorGetInfo result parameter. Clients, platforms, and servers must not send messages larger than 1024 bytes unless the authenticator's maxMsgSize indicates support for the larger message size. Authenticators may return the CTAP2_ERR_REQUEST_TOO_LARGE error if size or memory constraints are exceeded.