### PR TITLE
fido2/client.py: fix _ctap2_get_assertion

### DIFF
--- a/fido2/client.py
+++ b/fido2/client.py
@@ -381,7 +381,7 @@ class Fido2Client(object):
 
     def _ctap2_get_assertion(self, client_data, rp_id, allow_list, extensions,
                              up, uv, pin, timeout, on_keepalive):
-        info = self.ctap.get_info()
+        info = self.ctap2.get_info()
         pin_auth = None
         pin_protocol = None
         if pin:


### PR DESCRIPTION
self.ctap.get_info was removed in 1edb0d9d.  _ctap2_make_credential
was updated, but _ctap2_get_assertion wasn't.