### PR TITLE
Define relying party object

### DIFF
--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -36,7 +36,7 @@ Navigate to https://localhost:5000 in a supported web browser.
 from __future__ import print_function, absolute_import, unicode_literals
 
 from fido2.client import ClientData
-from fido2.server import Fido2Server
+from fido2.server import Fido2Server, RelyingParty
 from fido2.ctap2 import AttestationObject, AuthenticatorData
 from fido2 import cbor
 from flask import Flask, session, request, redirect, abort
@@ -47,10 +47,7 @@ import os
 app = Flask(__name__, static_url_path='')
 app.secret_key = os.urandom(32)  # Used for session.
 
-rp = {
-    'id': 'localhost',
-    'name': 'Demo server'
-}
+rp = RelyingParty('localhost', 'Demo server')
 server = Fido2Server(rp)
 
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,0 +1,37 @@
+from __future__ import absolute_import, unicode_literals
+
+import unittest
+
+from fido2.server import Fido2Server, RelyingParty
+
+
+class TestRelyingParty(unittest.TestCase):
+
+    def test_id_hash(self):
+        rp = RelyingParty('example.com')
+        rp_id_hash = (b'\xa3y\xa6\xf6\xee\xaf\xb9\xa5^7\x8c\x11\x804\xe2u\x1eh/'
+                      b'\xab\x9f-0\xab\x13\xd2\x12U\x86\xce\x19G')
+        self.assertEqual(rp.id_hash, rp_id_hash)
+
+
+class TestFido2Server(unittest.TestCase):
+
+    def test_register_begin_rp_no_icon(self):
+        rp = RelyingParty('example.com', 'Example')
+        server = Fido2Server(rp)
+
+        request = server.register_begin({})
+
+        self.assertEqual(request['publicKey']['rp'],
+                         {'id': 'example.com', 'name': 'Example'})
+
+    def test_register_begin_rp_icon(self):
+        rp = RelyingParty('example.com', 'Example',
+                          'http://example.com/icon.svg')
+        server = Fido2Server(rp)
+
+        request = server.register_begin({})
+
+        data = {'id': 'example.com', 'name': 'Example',
+                'icon': 'http://example.com/icon.svg'}
+        self.assertEqual(request['publicKey']['rp'], data)


### PR DESCRIPTION
Define an object for a relying party to be used in server API.

Having defined object in API is more strict solution which prevents errors in typos when compared to passing a dictionary. It may also provide further validation and other functions.

Also the functions from `rpid` module may be converted to methods of `RelyingParty` class.