### PR TITLE
Bugfix: PackedAttestation.verify should call CoseKey.parse(...)

### DIFF
--- a/fido2/attestation.py
+++ b/fido2/attestation.py
@@ -147,7 +147,7 @@ class PackedAttestation(Attestation):
             pub_key = CoseKey.for_alg(alg).from_cryptography_key(
                 cert.public_key())
         else:
-            pub_key = CoseKey(auth_data.credential_data.public_key)
+            pub_key = CoseKey.parse(auth_data.credential_data.public_key)
             if pub_key.ALGORITHM != alg:
                 raise InvalidData('Wrong algorithm of public key!')
         try:


### PR DESCRIPTION
In cases where an attestation is packed and does not contain an `x5c`, `PackedAttestation` incorrectly creates an instance of the `CoseKey` base class.

This PR fixes the bug by correctly calling `CoseKey.parse(...)` to instantiate the appropriate `CoseKey` subclass.