### PR TITLE
Add extra attestation certificate check from spec

### DIFF
--- a/fido2/attestation.py
+++ b/fido2/attestation.py
@@ -123,6 +123,8 @@ def _validate_attestation_certificate(cert, aaguid):
         raise InvalidData('Attestation certificate must have CA=false!')
     try:
         ext = cert.extensions.get_extension_for_oid(OID_AAGUID)
+        if ext.critical:
+            raise InvalidData('AAGUID extension must not be marked as critical')
         ext_aaguid = ext.value.value[2:]
         if ext_aaguid != aaguid:
             raise InvalidData('AAGUID in Authenticator data does not '


### PR DESCRIPTION
From the current version of the WebAuthn spec (emphasis mine):

> If the related attestation root certificate is used for multiple authenticator models, the Extension OID 1.3.6.1.4.1.45724.1.1.4 (id-fido-gen-ce-aaguid) MUST be present, containing the AAGUID as a 16-byte OCTET STRING. **The extension MUST NOT be marked as critical.**