### PR TITLE
Fix unknown attribute error in cryptography

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -47,7 +47,7 @@ setup(
     python_requires='>=2.7.6,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*',
     install_requires=[
         'six',
-        'cryptography>=1.0',
+        'cryptography>=1.5',
     ],
     extras_require={
         ':python_version < "3.4"': ['enum34']


### PR DESCRIPTION
If someone runs cryptography 1.0<=x<1.5 it will run into this error:
```
'_EllipticCurvePublicKey' object has no attribute 'verify'
```

This interface has been introduced in:
  https://github.com/pyca/cryptography/commit/2120a8e090ff8974d727f76aae5f2f9eac56656c

It is available in 1.5