### PR TITLE
Wrap invalid signature in authentication

### DIFF
--- a/fido2/server.py
+++ b/fido2/server.py
@@ -37,6 +37,7 @@ import os
 import six
 from enum import Enum, unique
 from cryptography.hazmat.primitives import constant_time
+from cryptography.exceptions import InvalidSignature
 
 
 def _verify_origin_for_rp(rp_id):
@@ -280,7 +281,11 @@ class Fido2Server(object):
 
         for cred in credentials:
             if cred.credential_id == credential_id:
-                cred.public_key.verify(auth_data + client_data.hash, signature)
+                try:
+                    cred.public_key.verify(auth_data + client_data.hash,
+                                           signature)
+                except InvalidSignature:
+                    raise ValueError('Invalid signature.')
                 return cred
         raise ValueError('Unknown credential ID.')
 

--- a/test/test_server.py
+++ b/test/test_server.py
@@ -1,8 +1,15 @@
 from __future__ import absolute_import, unicode_literals
 
+import json
 import unittest
+from binascii import a2b_hex
+import six
 
-from fido2.server import Fido2Server, RelyingParty
+from fido2.client import WEBAUTHN_TYPE, ClientData
+from fido2.ctap2 import AttestedCredentialData, AuthenticatorData
+from fido2.server import USER_VERIFICATION, Fido2Server, RelyingParty
+
+from .test_ctap2 import _ATT_CRED_DATA, _CRED_ID
 
 
 class TestRelyingParty(unittest.TestCase):
@@ -35,3 +42,19 @@ class TestFido2Server(unittest.TestCase):
         data = {'id': 'example.com', 'name': 'Example',
                 'icon': 'http://example.com/icon.svg'}
         self.assertEqual(request['publicKey']['rp'], data)
+
+    def test_authenticate_complete_invalid_signature(self):
+        rp = RelyingParty('example.com', 'Example')
+        server = Fido2Server(rp)
+
+        state = {'challenge': 'GAZPACHO!',
+                 'user_verification': USER_VERIFICATION.PREFERRED}
+        client_data_dict = {'challenge': 'GAZPACHO!',
+                            'origin': 'https://example.com',
+                            'type': WEBAUTHN_TYPE.GET_ASSERTION}
+        client_data = ClientData(json.dumps(client_data_dict).encode('utf-8'))
+        _AUTH_DATA = a2b_hex('A379A6F6EEAFB9A55E378C118034E2751E682FAB9F2D30AB13D2125586CE1947010000001D')  # noqa
+        with six.assertRaisesRegex(self, ValueError, 'Invalid signature.'):
+            server.authenticate_complete(
+                state, [AttestedCredentialData(_ATT_CRED_DATA)], _CRED_ID,
+                client_data, AuthenticatorData(_AUTH_DATA), b'INVALID')


### PR DESCRIPTION
`Fido2Server.authentication_complete` may raise `InvalidSignature` from cryptography library. I wrap this exception into a `ValueError` which is returned in all other error cases.