### PR TITLE
Fixes for TPM support

### DIFF
--- a/fido2/_tpm.py
+++ b/fido2/_tpm.py
@@ -318,6 +318,7 @@ class TpmiAlgKdf(IntEnum):
     section 9.28
     """
 
+    NULL = TPM_ALG_NULL
     KDF1_SP800_56A = 0x0020
     KDF2 = 0x0021
     KDF1_SP800_108 = 0x0022

--- a/fido2/_tpm.py
+++ b/fido2/_tpm.py
@@ -464,7 +464,7 @@ class TpmPublicFormat(object):
         return (
             "<TpmPublicFormat"
             " sign_alg=0x{self.sign_alg:x}"
-            " hash_alg=0x{self.hash_alg:x}"
+            " name_alg=0x{self.name_alg:x}"
             " attributes=0x{self.attributes:x}({self.attributes!r})"
             " auth_policy={self.auth_policy}"
             " parameters={self.parameters}"

--- a/test/test_tpm.py
+++ b/test/test_tpm.py
@@ -28,7 +28,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
-from fido2._tpm import TpmAttestationFormat
+from fido2._tpm import TpmAttestationFormat, TpmPublicFormat
 from binascii import a2b_hex
 
 import unittest
@@ -54,3 +54,9 @@ class TestTpmObject(unittest.TestCase):
         self.assertEqual(
             e.exception.args[0], "Not enough data to read (need: 20, had: 9)."
         )
+
+    def test_parse_public_ecc(self):
+        data = a2b_hex(
+            "0023000b00060472000000100010000300100020b9174cd199f77552afcffe6b1f069c032ffdc4f56068dec4e189e7967b3bf6b0002037bf8aa7d93fddb9507319141c6fa31c8e48a1c6da013603a9f6e3913d157c66"  # noqa
+        )
+        TpmPublicFormat.parse(data)


### PR DESCRIPTION
Got libtss2 working, I've been able to play a bit with a tpm and have it generate an ECC key.
I used that to generate a test missing from #72.

Also a minor fix for da5056913be4fba0392f4710a81e2ee0f3a8aa99 renaming a field.

somewhat superseeds #72