### PR TITLE
fix setuptools version incompatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,12 @@
 # ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from distutils.version import StrictVersion
+from distutils.version import LooseVersion
 from setuptools import setup, find_packages, __version__
 import re
 import sys
 
-if StrictVersion(__version__) < StrictVersion("20.2"):
+if LooseVersion(__version__) < LooseVersion("20.2"):
     sys.exit(
         "Your setuptools version does not support PEP 508.\n"
         "Please install setuptools 20.2 or later."


### PR DESCRIPTION
Hi, I just run into `ValueError: invalid version number '41.6.0.post20191030'` with setuptools 41.6.0 (conda distribution). This can fix it, I think loose version comparison would be good enough. 
Thanks