### PR TITLE
Use the advertised report size for INIT packets

### DIFF
--- a/fido2/_pyu2f/hidtransport.py
+++ b/fido2/_pyu2f/hidtransport.py
@@ -102,7 +102,7 @@ class UsbHidTransport(object):
 
     def ToWireFormat(self):
       """Serializes the packet."""
-      ret = bytearray(64)
+      ret = bytearray(self.packet_size)
       ret[0:4] = self.cid
       ret[4] = self.cmd
       struct.pack_into('>H', ret, 5, self.size)


### PR DESCRIPTION
The `ToWireFormat` function of `InitPacket` currently uses a fixed report size of 64 instead of the report size obtained from the HID device's report descriptor, which makes the `python-fido2` library incompatible with devices with non-standard report sizes. This commit makes it compatible by reusing the `packet_size` dependent logic from `ContPacket`.