### PR TITLE
macOS: add support for ≥512-byte IO registry paths

### DIFF
--- a/test/_pyu2f/test_macos.py
+++ b/test/_pyu2f/test_macos.py
@@ -60,7 +60,7 @@ class MacOsTest(unittest.TestCase):
     init_mock_cf(cf)
     init_mock_get_int_property(GetDeviceIntProperty)
 
-    device = macos.MacOsHidDevice('fakepath')
+    device = macos.MacOsHidDevice('1')
 
     self.assertEqual(64, device.GetInReportDataLength())
     self.assertEqual(64, device.GetOutReportDataLength())
@@ -73,7 +73,7 @@ class MacOsTest(unittest.TestCase):
     init_mock_cf(cf)
     init_mock_get_int_property(GetDeviceIntProperty)
 
-    device = macos.MacOsHidDevice('fakepath')
+    device = macos.MacOsHidDevice('1')
 
     # Write 64 bytes to device
     data = bytearray(range(64))
@@ -109,7 +109,7 @@ class MacOsTest(unittest.TestCase):
     # Make set report call return failure (non-zero)
     iokit.IOHIDDeviceSetReport.return_value = -1
 
-    device = macos.MacOsHidDevice('fakepath')
+    device = macos.MacOsHidDevice('1')
 
     # Write 64 bytes to device
     data = bytearray(range(64))
@@ -126,7 +126,7 @@ class MacOsTest(unittest.TestCase):
     init_mock_cf(cf)
     init_mock_get_int_property(GetDeviceIntProperty)
 
-    device = macos.MacOsHidDevice('fakepath')
+    device = macos.MacOsHidDevice('1')
 
     # Call callback for IN report
     report = (ctypes.c_uint8 * 64)()


### PR DESCRIPTION
## tl;dr

This PR improves macOS compatibility by changing the key used for accessing USB HID entries from a character-based path to a unique unsigned 64-bit number.

## Issue description

There is a [well-documented shortcoming](https://github.com/signal11/hidapi/issues/301) in the way macOS’s IOKit manages IORegistry entries. This causes USB HID entries to be [inaccessible by path](https://developer.apple.com/documentation/iokit/1514229-ioregistryentrygetpath?language=objc) if their IORegistry path length is [512 bytes](https://developer.apple.com/documentation/kernel/io_string_t?language=objc) or more.

Path lengths over 512 bytes have become more common. With current Macs now supporting external GPUs and Thunderbolt 3 chains, more and more intermediate nodes have been introduced into the IO tree, causing registry paths to become longer.

At the same time, IOKit’s path-based API still only supports path lengths up to 512 bytes. That’s become an issue especially for USB, whose topology tends to include multiple hubs, both built into the Mac and external ones.

Because of this, I got an error message whenever I tried to run any `ykman fido` command. In fact, I haven’t been able to set up my YubiKey 5 before I finally found the time to write this fix.

## The fix

The fix is to use the [IORegistry entry ID instead of a path](https://github.com/signal11/hidapi/issues/301#issuecomment-264015645). Entry IDs are unsigned 64-bit numbers, which are [global to all tasks and valid until the next boot](https://developer.apple.com/documentation/kernel/ioregistryentry/1811281-getregistryentryid?language=objc).

An API trade-off had to be made here because python-fido2 uses the concept of a character-based IO device path as an abstraction for all platforms including Windows and Linux.  
Fortunately, it’s up to the implementation how to interpret the content of the `path` field. So for macOS, I just redefined `path` to be the decimal string representation of the entry ID. That should not affect the public interface of the python-fido2 library.

## See also

For more information, see also:

- [IORegistryEntryGetRegistryEntryID](https://developer.apple.com/documentation/iokit/1514719-ioregistryentrygetregistryentryi?language=objc)

- [IORegistryEntryIDMatching](https://developer.apple.com/documentation/iokit/1514880-ioregistryentryidmatching?language=objc)

- ~~[IOServiceGetMatchingServices](https://developer.apple.com/documentation/iokit/1514494-ioservicegetmatchingservices?language=occ)~~  
[IOServiceGetMatchingService](https://developer.apple.com/documentation/iokit/1514535-ioservicegetmatchingservice?language=objc) **Edit:** that one is even easier to use.
