### PR TITLE
macOS: add early return to __del__

### DIFF
--- a/fido2/_pyu2f/macos.py
+++ b/fido2/_pyu2f/macos.py
@@ -453,6 +453,10 @@ class MacOsHidDevice(base.HidDevice):
         raise OSError('Failed reading a response')
 
   def __del__(self):
+    if not hasattr(self, 'device_handle'):
+      logger.warn('Destroying MacOsHidDevice that has no device handle')
+      return
+
     # Unregister the callback
     iokit.IOHIDDeviceRegisterInputReportCallback(
         self.device_handle,


### PR DESCRIPTION
I ran into this situation on my Mac when `__init__` failed before obtaining a handle. In that case, the newly-constructed object would have no `device_handle` attribute.

When the time comes to destroy the object, `__del__` assumes that `self.device_handle` exists. That causes the following unhelpful user-facing error:

```
$ ykman fido info
Exception ignored in: <function MacOsHidDevice.__del__ at 0x10702b4c0>
Traceback (most recent call last):
  File "/usr/local/Cellar/ykman/3.1.1_1/libexec/lib/python3.8/site-packages/fido2/_pyu2f/macos.py", line 469, in __del__
    self.device_handle,
AttributeError: 'MacOsHidDevice' object has no attribute 'device_handle'
[…]
Error: Failed connecting to YubiKey 5 [OTP+FIDO+CCID]. Make sure the application have the required permissions.
```

One possible failure mode is the bug that #94 attempts to fix.  
There are still other legitimate reasons for `__init__` to fail and return early.

This PR adds a check to `__del__` and an early return.