### PR TITLE
USB HID: add product name and serial to descriptor.

### DIFF
--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -52,7 +52,7 @@ def enumerate_devices():
 for dev in enumerate_devices():
     print("CONNECT: %s" % dev)
     print("Product name: %s" % dev.product_name)
-    print("Serial number: %s" % dev.serial)
+    print("Serial number: %s" % dev.serial_number)
     print("CTAPHID protocol version: %d" % dev.version)
 
     if dev.capabilities & CAPABILITY.CBOR:

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -51,6 +51,8 @@ def enumerate_devices():
 
 for dev in enumerate_devices():
     print("CONNECT: %s" % dev)
+    print("Product  name: %s" % dev.product_name)
+    print("Serial number: %s" % dev.serial)
     print("CTAPHID protocol version: %d" % dev.version)
 
     if dev.capabilities & CAPABILITY.CBOR:

--- a/examples/get_info.py
+++ b/examples/get_info.py
@@ -51,7 +51,7 @@ def enumerate_devices():
 
 for dev in enumerate_devices():
     print("CONNECT: %s" % dev)
-    print("Product  name: %s" % dev.product_name)
+    print("Product name: %s" % dev.product_name)
     print("Serial number: %s" % dev.serial)
     print("CTAPHID protocol version: %d" % dev.version)
 

--- a/fido2/hid/__init__.py
+++ b/fido2/hid/__init__.py
@@ -147,9 +147,9 @@ class CtapHidDevice(CtapDevice):
         return self.descriptor.product_name
 
     @property
-    def serial(self):
+    def serial_number(self):
         """Serial number of device."""
-        return self.descriptor.serial
+        return self.descriptor.serial_number
 
     def call(self, cmd, data=b"", event=None, on_keepalive=None):
         event = event or Event()

--- a/fido2/hid/__init__.py
+++ b/fido2/hid/__init__.py
@@ -141,6 +141,16 @@ class CtapHidDevice(CtapDevice):
         """Capabilities supported by the device."""
         return self._capabilities
 
+    @property
+    def product_name(self):
+        """Product name of device."""
+        return self.descriptor.product_name
+
+    @property
+    def serial(self):
+        """Serial number of device."""
+        return self.descriptor.serial
+
     def call(self, cmd, data=b"", event=None, on_keepalive=None):
         event = event or Event()
         remaining = data

--- a/fido2/hid/base.py
+++ b/fido2/hid/base.py
@@ -47,7 +47,7 @@ class HidDescriptor(
             "report_size_in",
             "report_size_out",
             "product_name",
-            "serial",
+            "serial_number",
         ],
     )
 ):

--- a/fido2/hid/base.py
+++ b/fido2/hid/base.py
@@ -39,7 +39,16 @@ FIDO_USAGE = 0x1
 
 class HidDescriptor(
     namedtuple(
-        "HidDescriptor", ["path", "vid", "pid", "report_size_in", "report_size_out", "product_name", "serial"]
+        "HidDescriptor",
+        [
+            "path",
+            "vid",
+            "pid",
+            "report_size_in",
+            "report_size_out",
+            "product_name",
+            "serial",
+        ],
     )
 ):
     __slots__ = ()

--- a/fido2/hid/base.py
+++ b/fido2/hid/base.py
@@ -39,7 +39,7 @@ FIDO_USAGE = 0x1
 
 class HidDescriptor(
     namedtuple(
-        "HidDescriptor", ["path", "vid", "pid", "report_size_in", "report_size_out"]
+        "HidDescriptor", ["path", "vid", "pid", "report_size_in", "report_size_out", "product_name", "serial"]
     )
 ):
     __slots__ = ()

--- a/fido2/hid/freebsd.py
+++ b/fido2/hid/freebsd.py
@@ -32,12 +32,12 @@ def open_connection(descriptor):
     return FileCtapHidConnection(descriptor)
 
 
-def _read_descriptor(vid, pid, path):
+def _read_descriptor(vid, pid, name, serial, path):
     fd = os.open(path, os.O_RDONLY)
     data = uhid_freebsd.get_report_data(fd, 3)
     os.close(fd)
     max_in_size, max_out_size = parse_report_descriptor(data)
-    return HidDescriptor(path, vid, pid, max_in_size, max_out_size)
+    return HidDescriptor(path, vid, pid, max_in_size, max_out_size, name, serial)
 
 
 def get_descriptor(path):
@@ -45,7 +45,9 @@ def get_descriptor(path):
         if dev["path"] == path:
             vid = dev["vendor_id"]
             pid = dev["product_id"]
-            return _read_descriptor(vid, pid, path)
+            name = dev["product_desc"]
+            serial = dev["serial_number"] if "serial_number" in dev else ""
+            return _read_descriptor(vid, pid, name, serial, path)
     raise ValueError("Device not found")
 
 
@@ -53,8 +55,9 @@ def list_descriptors():
     descriptors = []
     for dev in uhid_freebsd.enumerate():
         try:
+            serial = dev["serial_number"] if "serial_number" in dev else ""
             descriptors.append(
-                _read_descriptor(dev["vendor_id"], dev["product_id"], dev["path"])
+                _read_descriptor(dev["vendor_id"], dev["product_id"], dev["product_desc"], serial, dev["path"])
             )
             logger.debug("Found CTAP device: %s", dev["path"])
         except ValueError:

--- a/fido2/hid/freebsd.py
+++ b/fido2/hid/freebsd.py
@@ -45,10 +45,8 @@ def get_descriptor(path):
         if dev["path"] == path:
             vid = dev["vendor_id"]
             pid = dev["product_id"]
-            name = dev["product_desc"]
-            name = name if name else None
-            serial = dev["serial_number"] if "serial_number" in dev else None
-            serial = serial if serial else None
+            name = dev["product_desc"] or None
+            serial = (dev["serial_number"] if "serial_number" in dev else None) or None
             return _read_descriptor(vid, pid, name, serial, path)
     raise ValueError("Device not found")
 
@@ -57,10 +55,8 @@ def list_descriptors():
     descriptors = []
     for dev in uhid_freebsd.enumerate():
         try:
-            name = dev["product_desc"]
-            name = name if name else None
-            serial = dev["serial_number"] if "serial_number" in dev else None
-            serial = serial if serial else None
+            name = dev["product_desc"] or None
+            serial = (dev["serial_number"] if "serial_number" in dev else None) or None
             descriptors.append(
                 _read_descriptor(
                     dev["vendor_id"], dev["product_id"], name, serial, dev["path"],

--- a/fido2/hid/freebsd.py
+++ b/fido2/hid/freebsd.py
@@ -57,7 +57,13 @@ def list_descriptors():
         try:
             serial = dev["serial_number"] if "serial_number" in dev else ""
             descriptors.append(
-                _read_descriptor(dev["vendor_id"], dev["product_id"], dev["product_desc"], serial, dev["path"])
+                _read_descriptor(
+                    dev["vendor_id"],
+                    dev["product_id"],
+                    dev["product_desc"],
+                    serial,
+                    dev["path"],
+                )
             )
             logger.debug("Found CTAP device: %s", dev["path"])
         except ValueError:

--- a/fido2/hid/freebsd.py
+++ b/fido2/hid/freebsd.py
@@ -46,7 +46,9 @@ def get_descriptor(path):
             vid = dev["vendor_id"]
             pid = dev["product_id"]
             name = dev["product_desc"]
-            serial = dev["serial_number"] if "serial_number" in dev else ""
+            name = name if name else None
+            serial = dev["serial_number"] if "serial_number" in dev else None
+            serial = serial if serial else None
             return _read_descriptor(vid, pid, name, serial, path)
     raise ValueError("Device not found")
 
@@ -55,14 +57,13 @@ def list_descriptors():
     descriptors = []
     for dev in uhid_freebsd.enumerate():
         try:
-            serial = dev["serial_number"] if "serial_number" in dev else ""
+            name = dev["product_desc"]
+            name = name if name else None
+            serial = dev["serial_number"] if "serial_number" in dev else None
+            serial = serial if serial else None
             descriptors.append(
                 _read_descriptor(
-                    dev["vendor_id"],
-                    dev["product_id"],
-                    dev["product_desc"],
-                    serial,
-                    dev["path"],
+                    dev["vendor_id"], dev["product_id"], name, serial, dev["path"],
                 )
             )
             logger.debug("Found CTAP device: %s", dev["path"])

--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -58,11 +58,13 @@ def get_descriptor(path):
         buf = array("B", [0] * 128)
         fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
         name = buf.tobytes().decode()
+        name = name if name else None
 
         # Read unique ID
         buf = array("B", [0] * 64)
         fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
         serial = buf.tobytes().decode()
+        serial = serial if serial else None
 
         # Read report descriptor
         buf = array("B", [0] * 4)

--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -33,6 +33,8 @@ logger = logging.getLogger(__name__)
 HIDIOCGRAWINFO = 0x80084803
 HIDIOCGRDESCSIZE = 0x80044801
 HIDIOCGRDESC = 0x90044802
+HIDIOCGRAWNAME = 0x90044804
+HIDIOCGRAWUNIQ = 0x90044808
 
 
 class LinuxCtapHidConnection(FileCtapHidConnection):
@@ -52,6 +54,16 @@ def get_descriptor(path):
         fcntl.ioctl(f, HIDIOCGRAWINFO, buf, True)
         _, vid, pid = struct.unpack("<IHH", buf)
 
+        # Read product
+        buf = array("B", [0] * 128)
+        fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
+        name = buf.tobytes().decode()
+
+        # Read unique ID
+        buf = array("B", [0] * 64)
+        fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
+        serial = buf.tobytes().decode()
+
         # Read report descriptor
         buf = array("B", [0] * 4)
         fcntl.ioctl(f, HIDIOCGRDESCSIZE, buf, True)
@@ -61,7 +73,7 @@ def get_descriptor(path):
 
     data = bytearray(buf[4:])
     max_in_size, max_out_size = parse_report_descriptor(data)
-    return HidDescriptor(path, vid, pid, max_in_size, max_out_size)
+    return HidDescriptor(path, vid, pid, max_in_size, max_out_size, name, serial)
 
 
 def list_descriptors():

--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -57,14 +57,12 @@ def get_descriptor(path):
         # Read product
         buf = array("B", [0] * 128)
         fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
-        name = buf.tobytes().decode()
-        name = name if name else None
+        name = buf.tobytes().decode() or None
 
         # Read unique ID
         buf = array("B", [0] * 64)
         fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
-        serial = buf.tobytes().decode()
-        serial = serial if serial else None
+        serial = buf.tobytes().decode() or None
 
         # Read report descriptor
         buf = array("B", [0] * 4)

--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -57,12 +57,12 @@ def get_descriptor(path):
         # Read product
         buf = array("B", [0] * 128)
         fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
-        name = buf.tobytes().decode() or None
+        name = bytearray(buf).decode("utf-8") or None
 
         # Read unique ID
         buf = array("B", [0] * 64)
         fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
-        serial = buf.tobytes().decode() or None
+        serial = bytearray(buf).decode("utf-8") or None
 
         # Read report descriptor
         buf = array("B", [0] * 4)

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -361,7 +361,7 @@ def get_string_property(dev, key):
         return None
 
     try:
-        value = out.raw.decode("utf-8")
+        value = out.value.decode("utf-8")
         return value if value else None
     except UnicodeDecodeError:
         return None

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -143,7 +143,12 @@ cf.CFStringCreateWithCString.argtypes = [
     ctypes.c_uint32,
 ]
 cf.CFStringGetCString.restype = ctypes.c_bool
-cf.CFStringGetCString.argtypes = [CF_TYPE_REF, ctypes.c_char_p, CF_INDEX, CF_STRING_ENCODING]
+cf.CFStringGetCString.argtypes = [
+    CF_TYPE_REF,
+    ctypes.c_char_p,
+    CF_INDEX,
+    CF_STRING_ENCODING,
+]
 cf.CFGetTypeID.restype = CF_TYPE_ID
 cf.CFGetTypeID.argtypes = [CF_TYPE_REF]
 cf.CFNumberGetTypeID.restype = CF_TYPE_ID
@@ -301,7 +306,11 @@ class MacCtapHidConnection(CtapHidConnection):
 
     def write_packet(self, packet):
         result = iokit.IOHIDDeviceSetReport(
-            self.handle, K_IO_HID_REPORT_TYPE_OUTPUT, 0, packet, len(packet),
+            self.handle,
+            K_IO_HID_REPORT_TYPE_OUTPUT,
+            0,
+            packet,
+            len(packet),
         )
 
         # Non-zero status indicates failure
@@ -336,6 +345,7 @@ def get_int_property(dev, key):
 
     return out.value
 
+
 def get_string_property(dev, key):
     """Reads string property from the HID device."""
     cf_key = cf.CFStringCreateWithCString(None, key, 0)
@@ -348,14 +358,16 @@ def get_string_property(dev, key):
         raise OSError("Expected string type, got {}".format(cf.CFGetTypeID(type_ref)))
 
     out = ctypes.create_string_buffer(128)
-    ret = cf.CFStringGetCString(type_ref, out, ctypes.sizeof(out), CF_STRING_BUILTIN_ENCODINGS_UTF8)
+    ret = cf.CFStringGetCString(
+        type_ref, out, ctypes.sizeof(out), CF_STRING_BUILTIN_ENCODINGS_UTF8
+    )
     if not ret:
-        return ''
+        return ""
 
     try:
-        return out.raw.decode('utf-8')
+        return out.raw.decode("utf-8")
     except:
-        return ''
+        return ""
 
 
 def get_device_id(handle):
@@ -409,7 +421,9 @@ def _get_descriptor_from_handle(handle):
         serial = get_string_property(handle, HID_DEVICE_PROPERTY_SERIAL_NUMBER)
         size_in = get_int_property(handle, HID_DEVICE_PROPERTY_MAX_INPUT_REPORT_SIZE)
         size_out = get_int_property(handle, HID_DEVICE_PROPERTY_MAX_OUTPUT_REPORT_SIZE)
-        return HidDescriptor(str(device_id), vid, pid, size_in, size_out, product, serial)
+        return HidDescriptor(
+            str(device_id), vid, pid, size_in, size_out, product, serial
+        )
     raise ValueError("Not a CTAP device")
 
 

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -366,7 +366,7 @@ def get_string_property(dev, key):
 
     try:
         return out.raw.decode("utf-8")
-    except:
+    except Exception:
         return ""
 
 

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -34,6 +34,7 @@ logger = logging.getLogger(__name__)
 HID_DEVICE_PROPERTY_VENDOR_ID = b"VendorID"
 HID_DEVICE_PROPERTY_PRODUCT_ID = b"ProductID"
 HID_DEVICE_PROPERTY_PRODUCT = b"Product"
+HID_DEVICE_PROPERTY_SERIAL_NUMBER = b"SerialNumber"
 HID_DEVICE_PROPERTY_PRIMARY_USAGE = b"PrimaryUsage"
 HID_DEVICE_PROPERTY_PRIMARY_USAGE_PAGE = b"PrimaryUsagePage"
 HID_DEVICE_PROPERTY_MAX_INPUT_REPORT_SIZE = b"MaxInputReportSize"
@@ -81,6 +82,8 @@ CF_MUTABLE_DICTIONARY_REF = ctypes.c_void_p
 CF_TYPE_ID = ctypes.c_ulong
 CF_INDEX = ctypes.c_long
 CF_TIME_INTERVAL = ctypes.c_double
+CF_STRING_ENCODING = ctypes.c_uint32
+CF_STRING_BUILTIN_ENCODINGS_UTF8 = 134217984
 IO_RETURN = ctypes.c_uint
 IO_HID_REPORT_TYPE = ctypes.c_uint
 IO_OPTION_BITS = ctypes.c_uint
@@ -139,9 +142,12 @@ cf.CFStringCreateWithCString.argtypes = [
     ctypes.c_char_p,
     ctypes.c_uint32,
 ]
+cf.CFStringGetCString.restype = ctypes.c_bool
+cf.CFStringGetCString.argtypes = [CF_TYPE_REF, ctypes.c_char_p, CF_INDEX, CF_STRING_ENCODING]
 cf.CFGetTypeID.restype = CF_TYPE_ID
 cf.CFGetTypeID.argtypes = [CF_TYPE_REF]
 cf.CFNumberGetTypeID.restype = CF_TYPE_ID
+cf.CFStringGetTypeID.restype = CF_TYPE_ID
 cf.CFNumberGetValue.restype = ctypes.c_int
 cf.CFRunLoopGetCurrent.restype = CF_RUN_LOOP_REF
 cf.CFRunLoopGetCurrent.argtypes = []
@@ -330,6 +336,27 @@ def get_int_property(dev, key):
 
     return out.value
 
+def get_string_property(dev, key):
+    """Reads string property from the HID device."""
+    cf_key = cf.CFStringCreateWithCString(None, key, 0)
+    type_ref = iokit.IOHIDDeviceGetProperty(dev, cf_key)
+    cf.CFRelease(cf_key)
+    if not type_ref:
+        return None
+
+    if cf.CFGetTypeID(type_ref) != cf.CFStringGetTypeID():
+        raise OSError("Expected string type, got {}".format(cf.CFGetTypeID(type_ref)))
+
+    out = ctypes.create_string_buffer(128)
+    ret = cf.CFStringGetCString(type_ref, out, ctypes.sizeof(out), CF_STRING_BUILTIN_ENCODINGS_UTF8)
+    if not ret:
+        return ''
+
+    try:
+        return out.raw.decode('utf-8')
+    except:
+        return ''
+
 
 def get_device_id(handle):
     """Obtains the unique IORegistry entry ID for the device.
@@ -378,9 +405,11 @@ def _get_descriptor_from_handle(handle):
         device_id = get_device_id(handle)
         vid = get_int_property(handle, HID_DEVICE_PROPERTY_VENDOR_ID)
         pid = get_int_property(handle, HID_DEVICE_PROPERTY_PRODUCT_ID)
+        product = get_string_property(handle, HID_DEVICE_PROPERTY_PRODUCT)
+        serial = get_string_property(handle, HID_DEVICE_PROPERTY_SERIAL_NUMBER)
         size_in = get_int_property(handle, HID_DEVICE_PROPERTY_MAX_INPUT_REPORT_SIZE)
         size_out = get_int_property(handle, HID_DEVICE_PROPERTY_MAX_OUTPUT_REPORT_SIZE)
-        return HidDescriptor(str(device_id), vid, pid, size_in, size_out)
+        return HidDescriptor(str(device_id), vid, pid, size_in, size_out, product, serial)
     raise ValueError("Not a CTAP device")
 
 

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -306,11 +306,7 @@ class MacCtapHidConnection(CtapHidConnection):
 
     def write_packet(self, packet):
         result = iokit.IOHIDDeviceSetReport(
-            self.handle,
-            K_IO_HID_REPORT_TYPE_OUTPUT,
-            0,
-            packet,
-            len(packet),
+            self.handle, K_IO_HID_REPORT_TYPE_OUTPUT, 0, packet, len(packet),
         )
 
         # Non-zero status indicates failure

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -358,12 +358,13 @@ def get_string_property(dev, key):
         type_ref, out, ctypes.sizeof(out), CF_STRING_BUILTIN_ENCODINGS_UTF8
     )
     if not ret:
-        return ""
+        return None
 
     try:
-        return out.raw.decode("utf-8")
-    except Exception:
-        return ""
+        value = out.raw.decode("utf-8")
+        return value if value else None
+    except UnicodeDecodeError:
+        return None
 
 
 def get_device_id(handle):

--- a/fido2/hid/macos.py
+++ b/fido2/hid/macos.py
@@ -361,8 +361,7 @@ def get_string_property(dev, key):
         return None
 
     try:
-        value = out.value.decode("utf-8")
-        return value if value else None
+        return out.value.decode("utf-8") or None
     except UnicodeDecodeError:
         return None
 

--- a/fido2/hid/openbsd.py
+++ b/fido2/hid/openbsd.py
@@ -106,7 +106,9 @@ def get_descriptor(path):
     vid = int(dev_info.udi_vendorNo)
     pid = int(dev_info.udi_productNo)
     name = dev_info.udi_product.decode("utf-8")
+    name = name if name else None
     serial = dev_info.udi_serial.decode("utf-8")
+    serial = serial if serial else None
 
     return HidDescriptor(path, vid, pid, MAX_U2F_HIDLEN, MAX_U2F_HIDLEN, name, serial)
 

--- a/fido2/hid/openbsd.py
+++ b/fido2/hid/openbsd.py
@@ -21,7 +21,7 @@ import select
 import os
 import os.path
 
-from ctypes import Structure, c_char, c_int, c_uint8, c_uint16
+from ctypes import Structure, c_char, c_int, c_uint8, c_uint16, c_uint32
 
 from .base import HidDescriptor, FileCtapHidConnection
 
@@ -57,10 +57,9 @@ class UsbDeviceInfo(Structure):
         ("udi_power", c_int),
         ("udi_nports", c_int),
         ("udi_devnames", c_char * USB_MAX_DEVNAMELEN * USB_MAX_DEVNAMES),
-        ("udi_ports", c_uint8 * 8),
+        ("udi_ports", c_uint32 * 16),
         ("udi_serial", c_char * USB_MAX_STRING_LEN),
     ]
-
 
 class OpenBsdCtapHidConnection(FileCtapHidConnection):
     def __init__(self, descriptor):
@@ -105,8 +104,10 @@ def get_descriptor(path):
 
     vid = int(dev_info.udi_vendorNo)
     pid = int(dev_info.udi_productNo)
+    name   = dev_info.udi_product.decode('utf-8')
+    serial = dev_info.udi_serial.decode('utf-8')
 
-    return HidDescriptor(path, vid, pid, MAX_U2F_HIDLEN, MAX_U2F_HIDLEN)
+    return HidDescriptor(path, vid, pid, MAX_U2F_HIDLEN, MAX_U2F_HIDLEN, name, serial)
 
 
 def list_descriptors():

--- a/fido2/hid/openbsd.py
+++ b/fido2/hid/openbsd.py
@@ -61,6 +61,7 @@ class UsbDeviceInfo(Structure):
         ("udi_serial", c_char * USB_MAX_STRING_LEN),
     ]
 
+
 class OpenBsdCtapHidConnection(FileCtapHidConnection):
     def __init__(self, descriptor):
         super(OpenBsdCtapHidConnection, self).__init__(descriptor)
@@ -104,8 +105,8 @@ def get_descriptor(path):
 
     vid = int(dev_info.udi_vendorNo)
     pid = int(dev_info.udi_productNo)
-    name   = dev_info.udi_product.decode('utf-8')
-    serial = dev_info.udi_serial.decode('utf-8')
+    name = dev_info.udi_product.decode("utf-8")
+    serial = dev_info.udi_serial.decode("utf-8")
 
     return HidDescriptor(path, vid, pid, MAX_U2F_HIDLEN, MAX_U2F_HIDLEN, name, serial)
 

--- a/fido2/hid/openbsd.py
+++ b/fido2/hid/openbsd.py
@@ -105,10 +105,8 @@ def get_descriptor(path):
 
     vid = int(dev_info.udi_vendorNo)
     pid = int(dev_info.udi_productNo)
-    name = dev_info.udi_product.decode("utf-8")
-    name = name if name else None
-    serial = dev_info.udi_serial.decode("utf-8")
-    serial = serial if serial else None
+    name = dev_info.udi_product.decode("utf-8") or None
+    serial = dev_info.udi_serial.decode("utf-8") or None
 
     return HidDescriptor(path, vid, pid, MAX_U2F_HIDLEN, MAX_U2F_HIDLEN, name, serial)
 

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -239,17 +239,17 @@ def get_vid_pid(device):
 
 
 def get_product_name(device):
-    buf = ctypes.create_string_buffer(256)
+    buf = ctypes.create_unicode_buffer(128)
 
     result = hid.HidD_GetProductString(device, buf, ctypes.c_ulong(ctypes.sizeof(buf)))
     if not result:
         return None
 
-    return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
+    return buf.value
 
 
 def get_serial(device):
-    buf = ctypes.create_string_buffer(256)
+    buf = ctypes.create_unicode_buffer(128)
 
     result = hid.HidD_GetSerialNumberString(
         device, buf, ctypes.c_ulong(ctypes.sizeof(buf))
@@ -257,7 +257,7 @@ def get_serial(device):
     if not result:
         return None
 
-    return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
+    return buf.value
 
 
 def get_descriptor(path):

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -247,22 +247,30 @@ def get_product_name(device):
     if not result:
         raise ctypes.WinError()
 
-    return buf.raw.decode(encoding = 'utf-16').rstrip('\u0000')
+    return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
 
 
 def get_serial(device):
     buf = ctypes.create_string_buffer(256)
 
-    result = hid.HidD_GetSerialNumberString(device, buf, ctypes.c_ulong(ctypes.sizeof(buf)))
+    result = hid.HidD_GetSerialNumberString(
+        device, buf, ctypes.c_ulong(ctypes.sizeof(buf))
+    )
     if not result:
         raise ctypes.WinError()
 
-    return buf.raw.decode(encoding = 'utf-16').rstrip('\u0000')
+    return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
 
 
 def get_descriptor(path):
     device = kernel32.CreateFileA(
-        path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE, None, OPEN_EXISTING, 0, None,
+        path,
+        0,
+        FILE_SHARE_READ | FILE_SHARE_WRITE,
+        None,
+        OPEN_EXISTING,
+        0,
+        None,
     )
     if device == INVALID_HANDLE_VALUE:
         raise ctypes.WinError()
@@ -286,7 +294,9 @@ def get_descriptor(path):
                 # Sizes here include 1-byte report ID, which we need to remove.
                 size_in = caps.InputReportByteLength - 1
                 size_out = caps.OutputReportByteLength - 1
-                return HidDescriptor(path, vid, pid, size_in, size_out, product_name, serial)
+                return HidDescriptor(
+                    path, vid, pid, size_in, size_out, product_name, serial
+                )
             raise ValueError("Not a CTAP device")
 
         finally:

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -262,13 +262,7 @@ def get_serial(device):
 
 def get_descriptor(path):
     device = kernel32.CreateFileA(
-        path,
-        0,
-        FILE_SHARE_READ | FILE_SHARE_WRITE,
-        None,
-        OPEN_EXISTING,
-        0,
-        None,
+        path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE, None, OPEN_EXISTING, 0, None,
     )
     if device == INVALID_HANDLE_VALUE:
         raise ctypes.WinError()

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -20,8 +20,6 @@ from __future__ import absolute_import
 
 from .base import HidDescriptor, CtapHidConnection, FIDO_USAGE_PAGE, FIDO_USAGE
 
-from array import array
-
 import ctypes
 import platform
 from ctypes import wintypes, LibraryLoader, WinDLL

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -243,7 +243,7 @@ def get_product_name(device):
 
     result = hid.HidD_GetProductString(device, buf, ctypes.c_ulong(ctypes.sizeof(buf)))
     if not result:
-        raise ctypes.WinError()
+        return None
 
     return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
 
@@ -255,7 +255,7 @@ def get_serial(device):
         device, buf, ctypes.c_ulong(ctypes.sizeof(buf))
     )
     if not result:
-        raise ctypes.WinError()
+        return None
 
     return buf.raw.decode(encoding="utf-16").rstrip("\u0000")
 

--- a/fido2/hid/windows.py
+++ b/fido2/hid/windows.py
@@ -20,6 +20,8 @@ from __future__ import absolute_import
 
 from .base import HidDescriptor, CtapHidConnection, FIDO_USAGE_PAGE, FIDO_USAGE
 
+from array import array
+
 import ctypes
 import platform
 from ctypes import wintypes, LibraryLoader, WinDLL
@@ -128,6 +130,8 @@ hid.HidD_FreePreparsedData.restype = wintypes.BOOLEAN
 hid.HidD_FreePreparsedData.argtypes = [PHIDP_PREPARSED_DATA]
 hid.HidD_GetProductString.restype = wintypes.BOOLEAN
 hid.HidD_GetProductString.argtypes = [HANDLE, ctypes.c_void_p, ctypes.c_ulong]
+hid.HidD_GetSerialNumberString.restype = wintypes.BOOLEAN
+hid.HidD_GetSerialNumberString.argtypes = [HANDLE, ctypes.c_void_p, ctypes.c_ulong]
 hid.HidP_GetCaps.restype = NTSTATUS
 hid.HidP_GetCaps.argtypes = [PHIDP_PREPARSED_DATA, ctypes.POINTER(HidCapabilities)]
 
@@ -236,6 +240,26 @@ def get_vid_pid(device):
     return attributes.VendorID, attributes.ProductID
 
 
+def get_product_name(device):
+    buf = ctypes.create_string_buffer(256)
+
+    result = hid.HidD_GetProductString(device, buf, ctypes.c_ulong(ctypes.sizeof(buf)))
+    if not result:
+        raise ctypes.WinError()
+
+    return buf.raw.decode(encoding = 'utf-16').rstrip('\u0000')
+
+
+def get_serial(device):
+    buf = ctypes.create_string_buffer(256)
+
+    result = hid.HidD_GetSerialNumberString(device, buf, ctypes.c_ulong(ctypes.sizeof(buf)))
+    if not result:
+        raise ctypes.WinError()
+
+    return buf.raw.decode(encoding = 'utf-16').rstrip('\u0000')
+
+
 def get_descriptor(path):
     device = kernel32.CreateFileA(
         path, 0, FILE_SHARE_READ | FILE_SHARE_WRITE, None, OPEN_EXISTING, 0, None,
@@ -257,10 +281,12 @@ def get_descriptor(path):
 
             if caps.UsagePage == FIDO_USAGE_PAGE and caps.Usage == FIDO_USAGE:
                 vid, pid = get_vid_pid(device)
+                product_name = get_product_name(device)
+                serial = get_serial(device)
                 # Sizes here include 1-byte report ID, which we need to remove.
                 size_in = caps.InputReportByteLength - 1
                 size_out = caps.OutputReportByteLength - 1
-                return HidDescriptor(path, vid, pid, size_in, size_out)
+                return HidDescriptor(path, vid, pid, size_in, size_out, product_name, serial)
             raise ValueError("Not a CTAP device")
 
         finally:

--- a/fido2/pcsc.py
+++ b/fido2/pcsc.py
@@ -94,12 +94,12 @@ class CtapPcscDevice(CtapDevice):
     @property
     def product_name(self):
         """Product name of device."""
-        return ''
+        return ""
 
     @property
     def serial(self):
         """Serial number of device."""
-        return ''
+        return ""
 
     def get_atr(self):
         """Get the ATR/ATS of the connected card."""

--- a/fido2/pcsc.py
+++ b/fido2/pcsc.py
@@ -91,6 +91,16 @@ class CtapPcscDevice(CtapDevice):
         """Capabilities supported by the device."""
         return self._capabilities
 
+    @property
+    def product_name(self):
+        """Product name of device."""
+        return ''
+
+    @property
+    def serial(self):
+        """Serial number of device."""
+        return ''
+
     def get_atr(self):
         """Get the ATR/ATS of the connected card."""
         return self._conn.getATR()

--- a/fido2/pcsc.py
+++ b/fido2/pcsc.py
@@ -94,12 +94,12 @@ class CtapPcscDevice(CtapDevice):
     @property
     def product_name(self):
         """Product name of device."""
-        return ""
+        return None
 
     @property
     def serial(self):
         """Serial number of device."""
-        return ""
+        return None
 
     def get_atr(self):
         """Get the ATR/ATS of the connected card."""

--- a/fido2/pcsc.py
+++ b/fido2/pcsc.py
@@ -97,7 +97,7 @@ class CtapPcscDevice(CtapDevice):
         return None
 
     @property
-    def serial(self):
+    def serial_number(self):
         """Serial number of device."""
         return None
 


### PR DESCRIPTION
I tried to add product name and serial number support to the internal descriptor for USB HID devices. If there is something similar for NFC devices it might be possible to add it, as well.

Tested in following environments:
 - Linux (Ubuntu 20.10, python3): OK (product name contains manufacturer)
 - Windows (Windows 10, python3): OK
 - MacOSX (Catalina, python3): OK
 - OpenBSD (6.8, python3): OK (Note:there have been changes in `struct usb_device_info`, see [OpenBSD bug mailing list](https://marc.info/?t=161565009600001&r=1&w=2). I don't know how this can be addressed to support older versions, too.)
 - FreeBSD (12.2, python3): OK (serial number support needs updated uhid-freebsd, see grembo/uhid-freebsd#1; fragmented CTAP messages did not work in my VM setup, but seems unrelated)