### PR TITLE
Linux: remove trailing zeroes from serial

### DIFF
--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -56,13 +56,13 @@ def get_descriptor(path):
 
         # Read product
         buf = array("B", [0] * 128)
-        fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
-        name = bytearray(buf).decode("utf-8") or None
+        length = fcntl.ioctl(f, HIDIOCGRAWNAME, buf, True)
+        name = bytearray(buf[: (length - 1)]).decode("utf-8") if length > 1 else None
 
         # Read unique ID
         buf = array("B", [0] * 64)
-        fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
-        serial = bytearray(buf).decode("utf-8") or None
+        length = fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
+        serial = bytearray(buf[: (length - 1)]).decode("utf-8") if length > 1 else None
 
         # Read report descriptor
         buf = array("B", [0] * 4)


### PR DESCRIPTION
The changes of #113 left trailing zeroes in the serial number and product name on Linux.

The `ioctl()` for retrieving the attributes returns the string length on success. Use the returned value to retrieve strings of the correct length.