### PR TITLE
win_api: make `get_version` more resilient - checks for api version in dict

### DIFF
--- a/fido2/win_api.py
+++ b/fido2/win_api.py
@@ -629,7 +629,10 @@ def get_version(class_name):
     :returns: Version of Struct to use.
     :rtype: int
     """
-    if class_name in WEBAUTHN_STRUCT_VERSIONS[WEBAUTHN_API_VERSION]:
+    if (
+        WEBAUTHN_API_VERSION in WEBAUTHN_STRUCT_VERSIONS and
+        class_name in WEBAUTHN_STRUCT_VERSIONS[WEBAUTHN_API_VERSION]
+    ):
         return WEBAUTHN_STRUCT_VERSIONS[WEBAUTHN_API_VERSION][class_name]
 
     return WEBAUTHN_STRUCT_VERSIONS[1][class_name]


### PR DESCRIPTION
Windows 11 is using WebAuthn API version 3. This causes a `KeyError` when using the API version to access a value in the `WEBAUTHN_STRUCT_VERSIONS` dict because it only has keys `1` and `2`.

This PR extends the conditional to first ensure that the API version is in the keys of `WEBAUTHN_STRUCT_VERSIONS` to avoid the `KeyError`.

As of right now, all API calls my application uses are working on Windows 11 with this small change.