### PR TITLE
Linux: Fail gracefully on invalid HIDIOCGRAWUNIQ

### DIFF
--- a/fido2/hid/linux.py
+++ b/fido2/hid/linux.py
@@ -60,9 +60,12 @@ def get_descriptor(path):
         name = bytearray(buf[: (length - 1)]).decode("utf-8") if length > 1 else None
 
         # Read unique ID
-        buf = array("B", [0] * 64)
-        length = fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
-        serial = bytearray(buf[: (length - 1)]).decode("utf-8") if length > 1 else None
+        try:
+            buf = array("B", [0] * 64)
+            length = fcntl.ioctl(f, HIDIOCGRAWUNIQ, buf, True)
+            serial = bytearray(buf[: (length - 1)]).decode("utf-8") if length > 1 else None
+        except OSError:
+            serial = None
 
         # Read report descriptor
         buf = array("B", [0] * 4)


### PR DESCRIPTION
Instead of waiting for someone to fix an issue for me I thought, why don't I just do it myself?

Fixes https://github.com/Yubico/python-fido2/issues/127