### PR TITLE
Modified Example Server

### DIFF
--- a/examples/server/Pipfile
+++ b/examples/server/Pipfile
@@ -6,6 +6,7 @@ url = "https://pypi.org/simple"
 [packages]
 flask = "*"
 pyOpenSSL = "*"
+pickle-mixin = "*"
 "5448283" = {editable = true, path = "./../.."}
 
 [scripts]

--- a/examples/server/Pipfile.lock
+++ b/examples/server/Pipfile.lock
@@ -111,6 +111,9 @@
             "editable": true,
             "path": "./../.."
         },
+        "pickle-mixin": {
+            "index": "pypi"
+        },
         "flask": {
             "hashes": [
                 "sha256:7b2fb8e934ddd50731893bdcdb00fc8c0315916f9fcd50d22c7cc1a95ab634e2",

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -83,7 +83,7 @@ def register_begin():
     return cbor.encode(registration_data)
 
 @app.route("/api/register/beginplatform", methods=["POST"])
-def register_begin():
+def register_begin_platform():
     credentials=read_key()
     registration_data, state = server.register_begin(
         {

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -82,6 +82,27 @@ def register_begin():
     print("\n\n\n\n")
     return cbor.encode(registration_data)
 
+@app.route("/api/register/beginplatform", methods=["POST"])
+def register_begin():
+    credentials=read_key()
+    registration_data, state = server.register_begin(
+        {
+            "id": b"user_id",
+            "name": "a_user",
+            "displayName": "A. User",
+            "icon": "https://example.com/image.png",
+        },
+        credentials,
+        user_verification="discouraged",
+        authenticator_attachment="platform",
+    )
+
+    session["state"] = state
+    print("\n\n\n\n")
+    print(registration_data)
+    print("\n\n\n\n")
+    return cbor.encode(registration_data)
+
 
 @app.route("/api/register/complete", methods=["POST"])
 def register_complete():

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -41,7 +41,7 @@ from fido2.server import Fido2Server
 from fido2.ctap2 import AttestationObject, AuthenticatorData
 from fido2 import cbor
 from flask import Flask, session, request, redirect, abort
-
+import pickle
 import os
 
 

--- a/examples/server/static/index.html
+++ b/examples/server/static/index.html
@@ -15,7 +15,8 @@
   <hr>
 
   <h2>Available actions</h2>
-  <a href="/register.html">Register</a><br>
+  <a href="/register_platform.html">Register Platform</a><br>
+  <a href="/register.html">Register Cross Platform</a><br>
   <a href="/authenticate.html">Authenticate</a><br>
 </body>
 </html>

--- a/examples/server/static/register_platform.html
+++ b/examples/server/static/register_platform.html
@@ -1,0 +1,49 @@
+<html>
+<head>
+  <title>Fido 2.0 webauthn demo</title>
+  <script src="/cbor.js"></script>
+  <style>
+    body { font-family: sans-serif; line-height: 1.5em; padding: 2em 10em; }
+    h1, h2 { color: #325F74; }
+    a { color: #0080ac; font-weight: bold; text-decoration: none;}
+    a:hover { text-decoration: underline; }
+  </style>
+</head>
+<body>
+  <h1>WebAuthn demo using python-fido2</h1>
+  <p>This demo requires a browser supporting the WebAuthn API!</p>
+  <hr>
+
+  <h2>Register a credential</h2>
+  <p>Touch your authenticator device now...</p>
+  <a href="/">Cancel</a>
+
+  <script>
+    fetch('/api/register/begin', {
+      method: 'POST',
+    }).then(function(response) {
+      if(response.ok) return response.arrayBuffer();
+      throw new Error('Error getting registration data!');
+    }).then(CBOR.decode).then(function(options) {
+      return navigator.credentials.create(options);
+    }).then(function(attestation) {
+      return fetch('/api/register/complete', {
+        method: 'POST',
+        headers: {'Content-Type': 'application/cbor'},
+        body: CBOR.encode({
+          "attestationObject": new Uint8Array(attestation.response.attestationObject),
+          "clientDataJSON": new Uint8Array(attestation.response.clientDataJSON),
+        })
+      });
+    }).then(function(response) {
+      var stat = response.ok ? 'successful' : 'unsuccessful';
+      alert('Registration ' + stat + ' More details in server log...');
+    }, function(reason) {
+      alert(reason);
+    }).then(function() {
+      window.location = '/';
+    });
+  </script>
+
+</body>
+</html>

--- a/examples/server/static/register_platform.html
+++ b/examples/server/static/register_platform.html
@@ -15,7 +15,7 @@
   <hr>
 
   <h2>Register a credential</h2>
-  <p>Touch your authenticator device now...</p>
+  <p>Enter platform credentials...</p>
   <a href="/">Cancel</a>
 
   <script>

--- a/examples/server/static/register_platform.html
+++ b/examples/server/static/register_platform.html
@@ -19,7 +19,7 @@
   <a href="/">Cancel</a>
 
   <script>
-    fetch('/api/register/begin', {
+    fetch('/api/register/beginplatform', {
       method: 'POST',
     }).then(function(response) {
       if(response.ok) return response.arrayBuffer();


### PR DESCRIPTION
Added support for platform authenticators. Earlier it was only cross-platform.
Added support for saving credentials to disk. Earlier it was only on memory and lost when the server was exited.

Edits made in examples/server.