### PR TITLE
Allow when user_verification is preferred and PIN is not set

### DIFF
--- a/fido2/client.py
+++ b/fido2/client.py
@@ -477,10 +477,6 @@ class _Ctap2ClientBackend(_ClientBackend):
 
         if (
             user_verification == UserVerificationRequirement.REQUIRED
-            or (
-                user_verification == UserVerificationRequirement.PREFERRED
-                and uv_supported
-            )
             or self.info.options.get("alwaysUv")
         ):
             if not uv_configured:


### PR DESCRIPTION
When user_verification is "preferred" and it's not configured in ubikey, allow authentication to proceed, 
As stated here: https://developers.yubico.com/WebAuthn/WebAuthn_Developer_Guide/User_Presence_vs_User_Verification.html

**PREFERRED**: This value indicates that the RP prefers user verification for the operation if possible, but will not fail the operation if the response does not have the ``AuthenticatorDataFlags.UV`` flag set.

