### PR TITLE
Fixes largeBlob to be consistent with CTAP2

### DIFF
--- a/fido2/ctap2/blob.py
+++ b/fido2/ctap2/blob.py
@@ -166,7 +166,7 @@ class LargeBlobs:
             self.ctap.large_blobs(
                 offset,
                 set=_set,
-                length=ln,
+                length=size if offset == 0 else None,
                 pin_uv_protocol=pin_uv_protocol,
                 pin_uv_param=pin_uv_param,
             )


### PR DESCRIPTION
[CTAP2 says](https://fidoalliance.org/specs/fido-v2.1-ps-20210615/fido-client-to-authenticator-protocol-v2.1-ps-errata-20220621.html#authenticatorLargeBlobs):
> The total length of a write operation. Present if, and only if, set is present and offset is zero.

Hapy to change the code style, but I wanted the change to be concise for clarity first. I tested the change with OpenSK. Doesn't mean my interpretation of the specification is necessarily correct. But if it is, the code actually works :)