### PR TITLE
Fix for when `uv==True` but `clientPin` is not on the device.

### DIFF
--- a/fido2/client.py
+++ b/fido2/client.py
@@ -529,8 +529,12 @@ class _Ctap2ClientBackend(_ClientBackend):
         pin_auth = None
         internal_uv = False
         if self._should_use_uv(user_verification, mc) or permissions:
-            client_pin = ClientPin(self.ctap2)
-            allow_internal_uv = not permissions
+            if ClientPin.is_supported(self.info):
+                client_pin = ClientPin(self.ctap2)
+                allow_internal_uv = not permissions
+            else:
+                client_pin = None
+                allow_internal_uv = True
             permissions |= (
                 ClientPin.PERMISSION.MAKE_CREDENTIAL
                 if mc


### PR DESCRIPTION
Fix for `_get_auth_params` for MakeCredential and GetAssertion operations. Used in cases where `_should_use_uv` is True, but `clientPin` is not advertised in CTAP info on the device.

It appears this circumstance was in mind when reading other parts of the code, and [checks are already in place](https://github.com/Yubico/python-fido2/blob/54cee2216a065620b04d0a4d6c75ecb2b506feda/fido2/client.py#LL510C24-L510C24). It was just the line in this PR that was overlooked. This forces `allow_internal_uv`, and everything else then works as expected.

This is fix 1 of 2 for #189