### PR TITLE
HMAC-secret use ClientPin even if ClientPin not advertised on device

### DIFF
--- a/fido2/ctap2/extensions.py
+++ b/fido2/ctap2/extensions.py
@@ -124,7 +124,9 @@ class HmacSecretExtension(Ctap2Extension):
         ):
             raise ValueError("Invalid salt length")
 
-        client_pin = ClientPin(self.ctap, self.pin_protocol)
+        # HMAC-secret extension requires clientPin even when
+        # clientPin is not advertised in CTAP info
+        client_pin = ClientPin(self.ctap, self.pin_protocol, require_support=False)
         key_agreement, self.shared_secret = client_pin._get_shared_secret()
         if self.pin_protocol is None:
             self.pin_protocol = client_pin.protocol

--- a/fido2/ctap2/pin.py
+++ b/fido2/ctap2/pin.py
@@ -253,8 +253,13 @@ class ClientPin:
     def is_supported(info):
         return "clientPin" in info.options
 
-    def __init__(self, ctap: Ctap2, protocol: Optional[PinProtocol] = None):
-        if not self.is_supported(ctap.info):
+    def __init__(
+            self,
+            ctap: Ctap2,
+            protocol: Optional[PinProtocol] = None,
+            require_support: Optional[bool] = True
+    ):
+        if require_support and not self.is_supported(ctap.info):
             raise ValueError("Authenticator does not support ClientPin")
 
         self.ctap = ctap


### PR DESCRIPTION
The Trezor model T implements HMAC-secret, but does not advertise "clientPin" support. This causes the hmac-secret extension to throw an exception.
The trezor does have a non-advertised minimal implementation of clientPin specifically for the use in the hmac-secret flow.

This PR allows the hmac-secret extension to instantiate a ClientPin even if clientPin is not advertised in CTAP info.

This is fix 2 of 2 for #189