### PR TITLE
Handle authenticators with UV that do not support ClientPin.

### DIFF
--- a/fido2/client.py
+++ b/fido2/client.py
@@ -502,7 +502,7 @@ class _Ctap2ClientBackend(_ClientBackend):
     ):
         # Prefer UV
         if self.info.options.get("uv"):
-            if self.info.options.get("pinUvAuthToken"):
+            if ClientPin.is_token_supported(self.info):
                 if self.user_interaction.request_uv(permissions, rp_id):
                     return client_pin.get_uv_token(
                         permissions, rp_id, event, on_keepalive


### PR DESCRIPTION
This allows instantiation of the ClientPin class on devices which do not support passing a client PIN. This is needed since the addition of getting a UV token allows usage without requiring PIN.