### PR TITLE
Skip TPM attestation test if SHA1 is unsupported.

### DIFF
--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -41,6 +41,7 @@ from fido2.attestation import (
     UnsupportedType,
     verify_x509_chain,
 )
+from cryptography.exceptions import UnsupportedAlgorithm, _Reasons
 
 import unittest
 
@@ -221,6 +222,14 @@ ee18128ed50dd7a855e54d2459db005""".replace(
         client_param = bytes.fromhex(
             "057a0ecbe7e3e99e8926941614f6af078c802b110be89eb221d69be2e17a1ba4"
         )
+
+        try:
+            res = attestation.verify(statement, auth_data, client_param)
+        except UnsupportedAlgorithm as e:
+            if e._reason is _Reasons.UNSUPPORTED_HASH:
+                self.skipTest(
+                    "SHA1 signature verification not supported on this machine"
+                )
 
         res = attestation.verify(statement, auth_data, client_param)
         self.assertEqual(res.attestation_type, AttestationType.ATT_CA)


### PR DESCRIPTION
This is the case on RHEL9, and possibly other distros.