### PR TITLE
Fix curve check for ES384 and ES512 verify().

### DIFF
--- a/fido2/cose.py
+++ b/fido2/cose.py
@@ -150,7 +150,7 @@ class ES384(CoseKey):
     _HASH_ALG = hashes.SHA384()
 
     def verify(self, message, signature):
-        if self[-1] != 1:
+        if self[-1] != 2:
             raise ValueError("Unsupported elliptic curve")
         ec.EllipticCurvePublicNumbers(
             bytes2int(self[-2]), bytes2int(self[-3]), ec.SECP384R1()
@@ -177,7 +177,7 @@ class ES512(CoseKey):
     _HASH_ALG = hashes.SHA512()
 
     def verify(self, message, signature):
-        if self[-1] != 1:
+        if self[-1] != 3:
             raise ValueError("Unsupported elliptic curve")
         ec.EllipticCurvePublicNumbers(
             bytes2int(self[-2]), bytes2int(self[-3]), ec.SECP521R1()


### PR DESCRIPTION
This PR fixes ES384 and ES512 verification.

Both algorithms perform a curve check to SECP256R1 (1), and should be checked to SECP384R1 (2) and SECP512R1 (3), respectively.