### PR TITLE
Fix packing sub_cmd.

### DIFF
--- a/fido2/ctap2/config.py
+++ b/fido2/ctap2/config.py
@@ -86,7 +86,7 @@ class Config:
             msg = (
                 b"\xff" * 32
                 + b"\x0d"
-                + struct.pack("<b", sub_cmd)
+                + struct.pack("<B", sub_cmd)
                 + (cbor.encode(params) if params else b"")
             )
             pin_uv_protocol = self.pin_uv.protocol.VERSION


### PR DESCRIPTION
sub_cmd is an unsigned char, since VENDOR_PROTOTYPE is 0xff. If not, it cannot be encoded.

Currently, Config.CMD.VENDOR_PROTOTYPE (0xFF) cannot be encoded, since it is encoded as `<b` (signed char). It must be encoded as `<B` (unsigned char).