### PR TITLE
run example server on http instead of https

### DIFF
--- a/examples/server/README.adoc
+++ b/examples/server/README.adoc
@@ -17,11 +17,13 @@ Once the environment has been created, you can run the server by running:
   $ poetry run server
 
 When the server is running, use a browser supporting WebAuthn and open
-https://localhost:5000 to access the website.
+http://localhost:5000 to access the website.
 
-NOTE: As this server uses a self-signed certificate, you will get warnings in
-your browser about the connection not being secure. This is expected, and you
-can safely proceed to the site.
+NOTE: Webauthn requires a secure context (HTTPS), which involves
+obtaining a valid TLS certificate. However, most browsers also treat
+http://localhost as a secure context. This example runs without TLS
+as a demo, but otherwise you should always use HTTPS with a valid
+certificate when using Webauthn.
 
 === Using the website
 The site allows you to register a WebAuthn credential, and to authenticate it.

--- a/examples/server/server/server.py
+++ b/examples/server/server/server.py
@@ -31,7 +31,7 @@ to register and use a credential.
 
 See the file README.adoc in this directory for details.
 
-Navigate to https://localhost:5000 in a supported web browser.
+Navigate to http://localhost:5000 in a supported web browser.
 """
 from fido2.webauthn import PublicKeyCredentialRpEntity, PublicKeyCredentialUserEntity
 from fido2.server import Fido2Server
@@ -121,7 +121,10 @@ def authenticate_complete():
 
 def main():
     print(__doc__)
-    app.run(host='localhost', debug=False)
+    # Note: using localhost without TLS, as some browsers do
+    # not allow Webauthn in case of TLS certificate errors.
+    # See https://lists.w3.org/Archives/Public/public-webauthn/2022Nov/0135.html
+    app.run(host="localhost", debug=False)
 
 
 if __name__ == "__main__":

--- a/examples/server/server/server.py
+++ b/examples/server/server/server.py
@@ -121,7 +121,7 @@ def authenticate_complete():
 
 def main():
     print(__doc__)
-    app.run(host='localhost',debug=False)
+    app.run(host='localhost', debug=False)
 
 
 if __name__ == "__main__":

--- a/examples/server/server/server.py
+++ b/examples/server/server/server.py
@@ -121,7 +121,7 @@ def authenticate_complete():
 
 def main():
     print(__doc__)
-    app.run(ssl_context="adhoc", debug=False)
+    app.run(host='localhost',debug=False)
 
 
 if __name__ == "__main__":

--- a/fido2/rpid.py
+++ b/fido2/rpid.py
@@ -63,9 +63,9 @@ def verify_rp_id(rp_id: str, origin: str) -> bool:
     url = urlparse(origin)
     host = url.hostname
     # Note that Webauthn requires a secure context, i.e. an origin with https scheme.
-    # However, most browsers also treat http://localhost as a secure context.
-    # See https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
-    if url.scheme != "https" and (url.scheme, hostname) != ("http", "localhost"):
+    # However, most browsers also treat http://localhost as a secure context. See
+    # https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
+    if url.scheme != "https" and (url.scheme, host) != ("http", "localhost"):
         return False
     if host == rp_id:
         return True

--- a/fido2/rpid.py
+++ b/fido2/rpid.py
@@ -62,9 +62,11 @@ def verify_rp_id(rp_id: str, origin: str) -> bool:
 
     url = urlparse(origin)
     host = url.hostname
-    if url.scheme != "https":
-        if url.scheme != "http" or host != 'localhost':
-            return False
+    # Note that Webauthn requires a secure context, i.e. an origin with https scheme.
+    # However, most browsers also treat http://localhost as a secure context.
+    # See https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
+    if url.scheme != "https" and (url.scheme, hostname) != ("http", "localhost"):
+        return False
     if host == rp_id:
         return True
     if host and host.endswith("." + rp_id) and rp_id not in suffixes:

--- a/fido2/rpid.py
+++ b/fido2/rpid.py
@@ -61,9 +61,10 @@ def verify_rp_id(rp_id: str, origin: str) -> bool:
         return False
 
     url = urlparse(origin)
-    if url.scheme != "https":
-        return False
     host = url.hostname
+    if url.scheme != "https":
+        if url.scheme != "http" or host != 'localhost':
+            return False
     if host == rp_id:
         return True
     if host and host.endswith("." + rp_id) and rp_id not in suffixes:

--- a/fido2/server.py
+++ b/fido2/server.py
@@ -452,8 +452,8 @@ def verify_app_id(app_id: str, origin: str) -> bool:
     url = urlparse(app_id)
     hostname = url.hostname
     # Note that FIDO U2F requires a secure context, i.e. an origin with https scheme.
-    # However, most browsers also treat http://localhost as a secure context.
-    # See https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
+    # However, most browsers also treat http://localhost as a secure context. See
+    # https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
     if url.scheme != "https" and (url.scheme, hostname) != ("http", "localhost"):
         return False
     if not hostname:

--- a/fido2/server.py
+++ b/fido2/server.py
@@ -450,9 +450,10 @@ def verify_app_id(app_id: str, origin: str) -> bool:
     :return: True if the App ID is usable by the origin, False if not.
     """
     url = urlparse(app_id)
-    if url.scheme != "https":
-        return False
     hostname = url.hostname
+    if url.scheme != "https":
+        if url.scheme != "http" or hostname != 'localhost':
+            return False
     if not hostname:
         return False
     return verify_rp_id(hostname, origin)

--- a/fido2/server.py
+++ b/fido2/server.py
@@ -451,9 +451,11 @@ def verify_app_id(app_id: str, origin: str) -> bool:
     """
     url = urlparse(app_id)
     hostname = url.hostname
-    if url.scheme != "https":
-        if url.scheme != "http" or hostname != 'localhost':
-            return False
+    # Note that FIDO U2F requires a secure context, i.e. an origin with https scheme.
+    # However, most browsers also treat http://localhost as a secure context.
+    # See https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
+    if url.scheme != "https" and (url.scheme, hostname) != ("http", "localhost"):
+        return False
     if not hostname:
         return False
     return verify_rp_id(hostname, origin)


### PR DESCRIPTION
Chromium-based browsers do not allow WebAuthn calls on https URLs that have certificate issues.

See https://lists.w3.org/Archives/Public/public-webauthn/2022Nov/0135.html

Changing this to http on localhost, which is considered a secure context in most browsers.

See https://groups.google.com/a/chromium.org/g/blink-dev/c/RC9dSw-O3fE/m/E3_0XaT0BAAJ
