### PR TITLE
Added timeout functionality on Server

### DIFF
--- a/examples/credential.py
+++ b/examples/credential.py
@@ -84,7 +84,7 @@ else:
         print("Authenticator supports User Verification")
 
 
-server = Fido2Server({"id": "example.com", "name": "Example RP"}, attestation="direct")
+server = Fido2Server({"id": "example.com", "name": "Example RP"}, attestation="direct", timeout=3600)
 
 user = {"id": b"user_id", "name": "A. User"}
 


### PR DESCRIPTION
Added:

- Parameter 'timeout' (Optional of type int) which signifies the request time for attestation and assertion operations to class Fido2Server.
- Added a timestamp in the 'state' value to handle timeout
- Added errors for request timed out on register_complete() and authenticate_complete() functions in server.