### PR TITLE
Replace logging.warn usage with logging.warning

### DIFF
--- a/fido2/mds3.py
+++ b/fido2/mds3.py
@@ -428,7 +428,7 @@ class MdsAttestationVerifier(AttestationVerifier):
 
             # Figure out which root to use
             if not entry.metadata_statement:
-                logging.warn("Matched entry has no metadata_statement, can't validate!")
+                logging.warning("Matched entry has no metadata_statement, can't validate!")
                 return None
 
             issuer = x509.load_der_x509_certificate(


### PR DESCRIPTION
logging.warn is an alias to logging.warning since Python 3.3 and will be removed in Python 3.13.