### PR TITLE
Fix webauthn_json_mapping behavior

### DIFF
--- a/examples/resident_key.py
+++ b/examples/resident_key.py
@@ -82,11 +82,10 @@ else:
         print("No Authenticator with support for resident key found!")
         sys.exit(1)
 
-    # Prefer UV if supported
-    if client.info.options.get("uv"):
+    # Prefer UV if supported and configured
+    if client.info.options.get("uv") or client.info.options.get("pinUvAuthToken"):
         uv = "preferred"
         print("Authenticator supports User Verification")
-
 
 server = Fido2Server({"id": "example.com", "name": "Example RP"}, attestation="direct")
 

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -30,7 +30,7 @@
 import unittest
 from unittest import mock
 from fido2 import cbor
-from fido2.utils import sha256, websafe_encode
+from fido2.utils import sha256
 from fido2.hid import CAPABILITY
 from fido2.ctap import CtapError
 from fido2.ctap1 import RegistrationData
@@ -51,7 +51,7 @@ REG_DATA = RegistrationData(
 )
 
 rp = {"id": "example.com", "name": "Example RP"}
-user = {"id": websafe_encode(b"user_id"), "name": "A. User"}
+user = {"id": b"user_id", "name": "A. User"}
 challenge = b"Y2hhbGxlbmdl"
 _INFO_NO_PIN = bytes.fromhex(
     "a60182665532465f5632684649444f5f325f3002826375766d6b686d61632d7365637265740350f8a011f38c0a4d15800617111f9edc7d04a462726bf5627570f564706c6174f469636c69656e7450696ef4051904b0068101"  # noqa E501

--- a/tests/test_webauthn.py
+++ b/tests/test_webauthn.py
@@ -257,7 +257,7 @@ class TestWebAuthnDataTypes(unittest.TestCase):
             b"request_challenge",
             [{"type": "public-key", "alg": -7}],
             10000,
-            [{"type": "public-key", "id": websafe_encode(b"credential_id")}],
+            [{"type": "public-key", "id": b"credential_id"}],
             {
                 "authenticatorAttachment": "platform",
                 "residentKey": "required",
@@ -290,7 +290,7 @@ class TestWebAuthnDataTypes(unittest.TestCase):
         self.assertIsNone(
             PublicKeyCredentialCreationOptions(
                 {"id": "example.com", "name": "Example"},
-                {"id": websafe_encode(b"user_id"), "name": "A. User"},
+                {"id": b"user_id", "name": "A. User"},
                 b"request_challenge",
                 [{"type": "public-key", "alg": -7}],
                 attestation="invalid",


### PR DESCRIPTION
This PR fixes the CBOR serialization which caused problems when using `webauthn_json_mapping` with the Fido2Client in certain cases, and corrects the behavior of dataclass constructors when passing dict values.