### PR TITLE
Support PRF evalByCredential

### DIFF
--- a/examples/cred_blob.py
+++ b/examples/cred_blob.py
@@ -82,9 +82,9 @@ else:
         sys.exit(1)
 
     # Prefer UV token if supported
-    if client.info.options.get("pinUvAuthToken") or client.info.options.get("uv"):
+    if client.info.options.get("uv") or client.info.options.get("bioEnroll"):
         uv = "preferred"
-        print("Authenticator supports UV token")
+        print("Authenticator is configured for User Verification")
 
 
 server = Fido2Server({"id": "example.com", "name": "Example RP"})

--- a/examples/credential.py
+++ b/examples/credential.py
@@ -79,7 +79,7 @@ else:
     client = Fido2Client(dev, "https://example.com", user_interaction=CliInteraction())
 
     # Prefer UV if supported and configured
-    if client.info.options.get("uv") or client.info.options.get("pinUvAuthToken"):
+    if client.info.options.get("uv") or client.info.options.get("bioEnroll"):
         uv = "preferred"
         print("Authenticator supports User Verification")
 

--- a/examples/large_blobs.py
+++ b/examples/large_blobs.py
@@ -88,9 +88,9 @@ else:
         sys.exit(1)
 
     # Prefer UV token if supported
-    if client.info.options.get("pinUvAuthToken") or client.info.options.get("uv"):
+    if client.info.options.get("uv") or client.info.options.get("bioEnroll"):
         uv = "preferred"
-        print("Authenticator supports UV token")
+        print("Authenticator is configured for User Verification")
 
 
 server = Fido2Server({"id": "example.com", "name": "Example RP"})

--- a/examples/prf.py
+++ b/examples/prf.py
@@ -149,12 +149,15 @@ result = result.get_response(0)
 output1 = result.extension_results["prf"]["results"]["first"]
 print("Authenticated, secret:", output1.hex())
 
-# Authenticate again, using two salts to generate two secrets:
+# Authenticate again, using two salts to generate two secrets.
+
+# This time we will use evalByCredential, which can be used if there are multiple
+# credentials which use different salts. Here it is not needed, but provided for
+# completeness of the example.
 
 # Generate a second salt for PRF:
 salt2 = os.urandom(32)
 print("Authenticate with second salt:", salt2.hex())
-
 # The first salt is reused, which should result in the same secret.
 
 result = client.get_assertion(

--- a/examples/resident_key.py
+++ b/examples/resident_key.py
@@ -83,9 +83,9 @@ else:
         sys.exit(1)
 
     # Prefer UV if supported and configured
-    if client.info.options.get("uv") or client.info.options.get("pinUvAuthToken"):
+    if client.info.options.get("uv") or client.info.options.get("bioEnroll"):
         uv = "preferred"
-        print("Authenticator supports User Verification")
+        print("Authenticator is configured for User Verification")
 
 server = Fido2Server({"id": "example.com", "name": "Example RP"}, attestation="direct")
 

--- a/fido2/client.py
+++ b/fido2/client.py
@@ -631,7 +631,7 @@ class _Ctap2ClientBackend(_ClientBackend):
         permissions = ClientPin.PERMISSION.MAKE_CREDENTIAL
         if exclude_list:
             # We need this for filtering the exclude_list
-            permissions = ClientPin.PERMISSION.GET_ASSERTION
+            permissions |= ClientPin.PERMISSION.GET_ASSERTION
 
         # Get extension permissions
         extension_instances = [cls(self.ctap2) for cls in self.extensions]

--- a/fido2/client.py
+++ b/fido2/client.py
@@ -654,8 +654,11 @@ class _Ctap2ClientBackend(_ClientBackend):
                 exclude_cred = self._filter_creds(
                     rp.id, exclude_list, pin_protocol, pin_token, event, on_keepalive
                 )
-                if exclude_cred:
-                    raise CtapError(CtapError.ERR.CREDENTIAL_EXCLUDED)
+                # We know the request will fail if exclude_cred is not None here
+                # BUT DO NOT FAIL EARLY! We still need to prompt for UP, so we keep
+                # processing the request
+            else:
+                exclude_cred = None
 
             # Process extensions
             extension_inputs = {}
@@ -691,7 +694,7 @@ class _Ctap2ClientBackend(_ClientBackend):
                     _as_cbor(rp),
                     _as_cbor(user),
                     _cbor_list(key_params),
-                    None,
+                    [_as_cbor(exclude_cred)] if exclude_cred else None,
                     extension_inputs or None,
                     options,
                     pin_auth,

--- a/fido2/ctap2/extensions.py
+++ b/fido2/ctap2/extensions.py
@@ -34,6 +34,7 @@ from ..utils import sha256
 from enum import Enum, unique
 from typing import Dict, Tuple, Any, Optional
 import abc
+import warnings
 
 
 class Ctap2Extension(abc.ABC):
@@ -51,6 +52,9 @@ class Ctap2Extension(abc.ABC):
         """Whether or not the extension is supported by the authenticator."""
         return self.NAME in self.ctap.info.extensions
 
+    def get_create_permissions(self, inputs: Dict[str, Any]) -> ClientPin.PERMISSION:
+        return ClientPin.PERMISSION(0)
+
     def process_create_input(self, inputs: Dict[str, Any]) -> Any:
         """Returns a value to include in the authenticator extension input,
         or None.
@@ -60,7 +64,11 @@ class Ctap2Extension(abc.ABC):
     def process_create_input_with_permissions(
         self, inputs: Dict[str, Any]
     ) -> Tuple[Any, ClientPin.PERMISSION]:
-        return self.process_create_input(inputs), ClientPin.PERMISSION(0)
+        warnings.warn(
+            "This method is deprecated, use get_create_permissions.", DeprecationWarning
+        )
+
+        return self.process_create_input(inputs), self.get_create_permissions(inputs)
 
     def process_create_output(
         self,
@@ -71,6 +79,9 @@ class Ctap2Extension(abc.ABC):
         """Return client extension output given attestation_response, or None."""
         return None
 
+    def get_get_permissions(self, inputs: Dict[str, Any]) -> ClientPin.PERMISSION:
+        return ClientPin.PERMISSION(0)
+
     def process_get_input(self, inputs: Dict[str, Any]) -> Any:
         """Returns a value to include in the authenticator extension input,
         or None.
@@ -80,7 +91,10 @@ class Ctap2Extension(abc.ABC):
     def process_get_input_with_permissions(
         self, inputs: Dict[str, Any]
     ) -> Tuple[Any, ClientPin.PERMISSION]:
-        return self.process_get_input(inputs), ClientPin.PERMISSION(0)
+        warnings.warn(
+            "This method is deprecated, use get_get_permissions.", DeprecationWarning
+        )
+        return self.process_get_input(inputs), self.get_get_permissions(inputs)
 
     def process_get_output(
         self,
@@ -209,9 +223,13 @@ class LargeBlobExtension(Ctap2Extension):
             "largeBlob": {"supported": attestation_response.large_blob_key is not None}
         }
 
-    def process_get_input_with_permissions(self, inputs):
+    def get_get_permissions(self, inputs):
+        if inputs.get("largeBlob", {}).get("write"):
+            return ClientPin.PERMISSION.LARGE_BLOB_WRITE
+        return ClientPin.PERMISSION(0)
+
+    def process_get_input(self, inputs):
         data = inputs.get("largeBlob", {})
-        permissions = ClientPin.PERMISSION(0)
         if data:
             if "support" in data or ("read" in data and "write" in data):
                 raise ValueError("Invalid set of parameters")
@@ -221,8 +239,7 @@ class LargeBlobExtension(Ctap2Extension):
                 self._action = True
             else:
                 self._action = data.get("write")
-                permissions = ClientPin.PERMISSION.LARGE_BLOB_WRITE
-        return True if data else None, permissions
+        return True if data else None
 
     def process_get_output(self, assertion_response, token, pin_protocol):
         blob_key = assertion_response.large_blob_key

--- a/fido2/pcsc.py
+++ b/fido2/pcsc.py
@@ -112,9 +112,7 @@ class CtapPcscDevice(CtapDevice):
         logger.log(LOG_LEVEL_TRAFFIC, "SEND: %s", apdu.hex())
         resp, sw1, sw2 = self._conn.transmit(list(apdu), protocol)
         response = bytes(resp)
-        logger.log(
-            LOG_LEVEL_TRAFFIC, "RECV: %s SW=%04X", response.hex(), sw1 << 8 + sw2
-        )
+        logger.log(LOG_LEVEL_TRAFFIC, "RECV: %s SW=%02X%02X", response.hex(), sw1, sw2)
 
         return response, sw1, sw2
 


### PR DESCRIPTION
This refactors extensions and the Fido2Client class to be able to support more complex extensions, such as evalByCredential in PRF.