### PR TITLE
Add support for Ed488

### DIFF
--- a/tests/test_cose.py
+++ b/tests/test_cose.py
@@ -189,5 +189,6 @@ class TestCoseKey(unittest.TestCase):
         self.assertEqual(CoseKey.for_alg(-48), cose.ESP384)
         self.assertEqual(CoseKey.for_alg(-49), cose.ESP512)
         self.assertEqual(CoseKey.for_alg(-50), cose.Ed25519)
+        self.assertEqual(CoseKey.for_alg(-51), cose.Ed448)
         self.assertEqual(CoseKey.for_alg(-257), cose.RS256)
         self.assertEqual(CoseKey.for_alg(-65535), cose.RS1)


### PR DESCRIPTION
Follow-up to #253. Previously the `EdDSA (-8)` identifier only allowed Curve25519; with the new fully-specified identifiers Curve448 is also possible.