### PR TITLE
Update fully-specified COSE algorithms to draft 12

### DIFF
--- a/fido2/cose.py
+++ b/fido2/cose.py
@@ -206,8 +206,8 @@ class ES384(CoseKey):
 
 
 class ESP384(ES384):
-    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-10.html#name-elliptic-curve-digital-sign  # noqa:E501
-    ALGORITHM = -48
+    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-12.html#name-elliptic-curve-digital-sign  # noqa:E501
+    ALGORITHM = -51
 
 
 class ES512(CoseKey):
@@ -239,8 +239,8 @@ class ES512(CoseKey):
 
 
 class ESP512(ES512):
-    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-10.html#name-elliptic-curve-digital-sign  # noqa:E501
-    ALGORITHM = -49
+    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-12.html#name-elliptic-curve-digital-sign  # noqa:E501
+    ALGORITHM = -52
 
 
 class RS256(CoseKey):
@@ -306,8 +306,8 @@ class EdDSA(CoseKey):
 
 
 class Ed25519(EdDSA):
-    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-10.html#name-edwards-curve-digital-signa  # noqa:E501
-    ALGORITHM = -50
+    # See: https://www.ietf.org/archive/id/draft-ietf-jose-fully-specified-algorithms-12.html#name-edwards-curve-digital-signa  # noqa:E501
+    ALGORITHM = -19
 
 
 class RS1(CoseKey):

--- a/tests/test_cose.py
+++ b/tests/test_cose.py
@@ -45,7 +45,7 @@ _RS256_KEY = a2b_hex(
 _EdDSA_KEY = a2b_hex(
     b"a4010103272006215820ee9b21803405d3cf45601e58b6f4c06ea93862de87d3af903c5870a5016e86f5"  # noqa E501
 )
-_Ed25519_KEY = _EdDSA_KEY[0:4] + a2b_hex("3831") + _EdDSA_KEY[5:]
+_Ed25519_KEY = _EdDSA_KEY[0:4] + a2b_hex("32") + _EdDSA_KEY[5:]
 
 
 class TestCoseKey(unittest.TestCase):
@@ -157,7 +157,7 @@ class TestCoseKey(unittest.TestCase):
             key,
             {
                 1: 1,
-                3: -50,
+                3: -19,
                 -1: 6,
                 -2: a2b_hex(
                     "EE9B21803405D3CF45601E58B6F4C06EA93862DE87D3AF903C5870A5016E86F5"
@@ -182,12 +182,12 @@ class TestCoseKey(unittest.TestCase):
         self.assertEqual(CoseKey.for_alg(-7), cose.ES256)
         self.assertEqual(CoseKey.for_alg(-8), cose.EdDSA)
         self.assertEqual(CoseKey.for_alg(-9), cose.ESP256)
+        self.assertEqual(CoseKey.for_alg(-19), cose.Ed25519)
         self.assertEqual(CoseKey.for_alg(-35), cose.ES384)
         self.assertEqual(CoseKey.for_alg(-36), cose.ES512)
         self.assertEqual(CoseKey.for_alg(-37), cose.PS256)
         self.assertEqual(CoseKey.for_alg(-47), cose.ES256K)
-        self.assertEqual(CoseKey.for_alg(-48), cose.ESP384)
-        self.assertEqual(CoseKey.for_alg(-49), cose.ESP512)
-        self.assertEqual(CoseKey.for_alg(-50), cose.Ed25519)
+        self.assertEqual(CoseKey.for_alg(-51), cose.ESP384)
+        self.assertEqual(CoseKey.for_alg(-52), cose.ESP512)
         self.assertEqual(CoseKey.for_alg(-257), cose.RS256)
         self.assertEqual(CoseKey.for_alg(-65535), cose.RS1)


### PR DESCRIPTION
These values had been [double-assigned to ML-DSA algorithms](https://github.com/w3c/webauthn/pull/2283#issuecomment-2860039020) and were therefore changed in draft 12:
https://datatracker.ietf.org/doc/draft-ietf-jose-fully-specified-algorithms/12/