### PR TITLE
Properly detect platform

### DIFF
--- a/fido2/hid/__init__.py
+++ b/fido2/hid/__init__.py
@@ -48,11 +48,11 @@ elif sys.platform == "win32":
     from . import windows as backend
 elif sys.platform == "darwin":
     from . import macos as backend
-elif sys.platform == "freebsd":
+elif sys.platform.startswith("freebsd"):
     from . import freebsd as backend
-elif sys.platform == "netbsd":
+elif sys.platform.startswith("netbsd"):
     from . import netbsd as backend
-elif sys.platform == "openbsd":
+elif sys.platform.startswith("openbsd"):
     from . import openbsd as backend
 else:
     raise Exception("Unsupported platform")


### PR DESCRIPTION
On FreeBSD, NetBSD, and (presumably) OpenBSD, `sys.plaform` returns platform name concatenated with the major version number. For example, for NetBSD 11.x, it returns `netbsd11`. Following Python documentation for [sys.platform](https://docs.python.org/3/library/sys.html#sys.platform), this pull request fixes platform detection in `hid` module.