### PR TITLE
Bump cryptography dependency to >= 45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
   "Topic :: Security :: Cryptography",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
-dependencies = ["cryptography (>=2.6, !=35, <49)"]
+dependencies = ["cryptography (>=45, <49)"]
 
 [project.optional-dependencies]
 pcsc = ["pyscard (>=1.9, <3)"]


### PR DESCRIPTION
The `group_order` attribute used in `fido2.arkg._BL.prf` was introduced in version 45. See https://cryptography.io/en/latest/hazmat/primitives/asymmetric/ec/#cryptography.hazmat.primitives.asymmetric.ec.EllipticCurve.group_order. Tests otherwise fail with:

```

=================================== FAILURES ===================================
__________________________ test_vectors[test_vector0] __________________________

test_vector = {'ctx': b'ARKG-P256.test vectors', 'ikm': b'@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_', 'ikm_bl': b'\x00\x01\x02\x03\x04\x05\x...x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f', 'ikm_kem': b' !"#$%&\'()*+,-./0123456789:;<=>?', ...}

    @pytest.mark.parametrize("test_vector", TEST_VECTORS)
    def test_vectors(test_vector):
        pub_key = ARKG_P256_PLACEHOLDER(
            {
                1: -65537,
                3: -65700,
                -1: {
                    1: 2,
                    3: -7,
                    -1: 1,
                    -2: test_vector["pk_bl"][1:33],
                    -3: test_vector["pk_bl"][33:65],
                },
                -2: {
                    1: 2,
                    3: -25,
                    -1: 1,
                    -2: test_vector["pk_kem"][1:33],
                    -3: test_vector["pk_kem"][33:65],
                },
                -3: -9,
            }
        )
    
>       pk_derived, args = pub_key.derive_public_key(test_vector["ikm"], test_vector["ctx"])

tests/test_arkg.py:105: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
fido2/cose.py:436: in derive_public_key
    pk, kh = self._ARKG.derive_public_key(
fido2/arkg.py:439: in derive_public_key
    ikm_tau, c = self.kem.encaps(pk_kem, ikm, ctx_kem)
fido2/arkg.py:354: in encaps
    k_prime, c_prime = self.sub_kem_encaps(pk, ikm, ctx_sub)
fido2/arkg.py:316: in sub_kem_encaps
    sk_prime = self.sub_kem_derive_key_pair(ikm)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = _KEM(crv=<cryptography.hazmat.primitives.asymmetric.ec.SECP256R1 object at 0x7953be069350>, Hash=<cryptography.hazmat.primitives.hashes.SHA256 object at 0x7953be20d750>, DST_ext=b'ARKG-ECDH.ARKG-P256')
ikm = b'@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_'

    def sub_kem_derive_key_pair(self, ikm: bytes) -> EllipticCurvePrivateKey:
        """
        Sub-Kem-Derive-Key-Pair(ikm) -> (pk, sk)
    
            sk = hash_to_field(ikm, 1) with the parameters:
                DST: 'ARKG-KEM-ECDH-KG.' || DST_ext
                F: GF(N), the scalar field
                  of the prime order subgroup of crv
                p: N
                m: 1
                L: The L defined in hash-to-crv-suite
                expand_message: The expand_message function
                                defined in hash-to-crv-suite
    
            pk = sk * G
        """
        htf = _HTF(
            b"ARKG-KEM-ECDH-KG." + self.DST_ext,
>           self.crv.group_order,
            48,
            self.Hash,
        )
E       AttributeError: 'SECP256R1' object has no attribute 'group_order'

fido2/arkg.py:290: AttributeError
__________________________ test_vectors[test_vector1] __________________________

test_vector = {'ctx': b'ARKG-P256.test vectors', 'ikm': b'\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\x...x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f', 'ikm_kem': b' !"#$%&\'()*+,-./0123456789:;<=>?', ...}

    @pytest.mark.parametrize("test_vector", TEST_VECTORS)
    def test_vectors(test_vector):
        pub_key = ARKG_P256_PLACEHOLDER(
            {
                1: -65537,
                3: -65700,
                -1: {
                    1: 2,
                    3: -7,
                    -1: 1,
                    -2: test_vector["pk_bl"][1:33],
                    -3: test_vector["pk_bl"][33:65],
                },
                -2: {
                    1: 2,
                    3: -25,
                    -1: 1,
                    -2: test_vector["pk_kem"][1:33],
                    -3: test_vector["pk_kem"][33:65],
                },
                -3: -9,
            }
        )
    
>       pk_derived, args = pub_key.derive_public_key(test_vector["ikm"], test_vector["ctx"])

tests/test_arkg.py:105: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
fido2/cose.py:436: in derive_public_key
    pk, kh = self._ARKG.derive_public_key(
fido2/arkg.py:439: in derive_public_key
    ikm_tau, c = self.kem.encaps(pk_kem, ikm, ctx_kem)
fido2/arkg.py:354: in encaps
    k_prime, c_prime = self.sub_kem_encaps(pk, ikm, ctx_sub)
fido2/arkg.py:316: in sub_kem_encaps
    sk_prime = self.sub_kem_derive_key_pair(ikm)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = _KEM(crv=<cryptography.hazmat.primitives.asymmetric.ec.SECP256R1 object at 0x7953be069350>, Hash=<cryptography.hazmat.primitives.hashes.SHA256 object at 0x7953be20d750>, DST_ext=b'ARKG-ECDH.ARKG-P256')
ikm = b'\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf'

    def sub_kem_derive_key_pair(self, ikm: bytes) -> EllipticCurvePrivateKey:
        """
        Sub-Kem-Derive-Key-Pair(ikm) -> (pk, sk)
    
            sk = hash_to_field(ikm, 1) with the parameters:
                DST: 'ARKG-KEM-ECDH-KG.' || DST_ext
                F: GF(N), the scalar field
                  of the prime order subgroup of crv
                p: N
                m: 1
                L: The L defined in hash-to-crv-suite
                expand_message: The expand_message function
                                defined in hash-to-crv-suite
    
            pk = sk * G
        """
        htf = _HTF(
            b"ARKG-KEM-ECDH-KG." + self.DST_ext,
>           self.crv.group_order,
            48,
            self.Hash,
        )
E       AttributeError: 'SECP256R1' object has no attribute 'group_order'

fido2/arkg.py:290: AttributeError
__________________________ test_vectors[test_vector2] __________________________

test_vector = {'ctx': b'ARKG-P256.test vectors.0', 'ikm': b'@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_', 'ikm_bl': b'\x00\x01\x02\x03\x04\x05...x10\x11\x12\x13\x14\x15\x16\x17\x18\x19\x1a\x1b\x1c\x1d\x1e\x1f', 'ikm_kem': b' !"#$%&\'()*+,-./0123456789:;<=>?', ...}

    @pytest.mark.parametrize("test_vector", TEST_VECTORS)
    def test_vectors(test_vector):
        pub_key = ARKG_P256_PLACEHOLDER(
            {
                1: -65537,
                3: -65700,
                -1: {
                    1: 2,
                    3: -7,
                    -1: 1,
                    -2: test_vector["pk_bl"][1:33],
                    -3: test_vector["pk_bl"][33:65],
                },
                -2: {
                    1: 2,
                    3: -25,
                    -1: 1,
                    -2: test_vector["pk_kem"][1:33],
                    -3: test_vector["pk_kem"][33:65],
                },
                -3: -9,
            }
        )
    
>       pk_derived, args = pub_key.derive_public_key(test_vector["ikm"], test_vector["ctx"])

tests/test_arkg.py:105: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
fido2/cose.py:436: in derive_public_key
    pk, kh = self._ARKG.derive_public_key(
fido2/arkg.py:439: in derive_public_key
    ikm_tau, c = self.kem.encaps(pk_kem, ikm, ctx_kem)
fido2/arkg.py:354: in encaps
    k_prime, c_prime = self.sub_kem_encaps(pk, ikm, ctx_sub)
fido2/arkg.py:316: in sub_kem_encaps
    sk_prime = self.sub_kem_derive_key_pair(ikm)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = _KEM(crv=<cryptography.hazmat.primitives.asymmetric.ec.SECP256R1 object at 0x7953be069350>, Hash=<cryptography.hazmat.primitives.hashes.SHA256 object at 0x7953be20d750>, DST_ext=b'ARKG-ECDH.ARKG-P256')
ikm = b'@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\]^_'

    def sub_kem_derive_key_pair(self, ikm: bytes) -> EllipticCurvePrivateKey:
        """
        Sub-Kem-Derive-Key-Pair(ikm) -> (pk, sk)
    
            sk = hash_to_field(ikm, 1) with the parameters:
                DST: 'ARKG-KEM-ECDH-KG.' || DST_ext
                F: GF(N), the scalar field
                  of the prime order subgroup of crv
                p: N
                m: 1
                L: The L defined in hash-to-crv-suite
                expand_message: The expand_message function
                                defined in hash-to-crv-suite
    
            pk = sk * G
        """
        htf = _HTF(
            b"ARKG-KEM-ECDH-KG." + self.DST_ext,
>           self.crv.group_order,
            48,
            self.Hash,
        )
E       AttributeError: 'SECP256R1' object has no attribute 'group_order'

fido2/arkg.py:290: AttributeError
=============================== warnings summary ===============================
<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyPacked has no __module__ attribute

<frozen importlib._bootstrap>:488
  <frozen importlib._bootstrap>:488: DeprecationWarning: builtin type SwigPyObject has no __module__ attribute

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=========================== short test summary info ============================
FAILED tests/test_arkg.py::test_vectors[test_vector0] - AttributeError: 'SECP...
FAILED tests/test_arkg.py::test_vectors[test_vector1] - AttributeError: 'SECP...
FAILED tests/test_arkg.py::test_vectors[test_vector2] - AttributeError: 'SECP...
================== 3 failed, 146 passed, 2 warnings in 0.52s ===================
Failed to dlopen libpcsclite.so.1: libpcsclite.so.1: cannot open shared object file: No such file or directory!<sys>:0: DeprecationWarning: builtin type swigvarlink has no __module__ attribute
E: pybuild pybuild:389: test: plugin pyproject failed with: exit code=1: cd /<<PKGBUILDDIR>>/.pybuild/cpython3_3.13_fido2/build; python3.13 -m pytest --ignore=tests/device
dh_auto_test: error: pybuild --test --test-pytest -i python{version} -p 3.13 returned exit code 13
make: *** [debian/rules:8: binary] Error 25
``